### PR TITLE
Add support for GNU Make invocation as gmake

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/GnuMakeGccParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/GnuMakeGccParser.java
@@ -24,7 +24,7 @@ public class GnuMakeGccParser extends RegexpLineParser {
             + "(?:.*\\[.*\\])?\\s*" // ANT_TASK
             + "(.*\\.[chpimxsola0-9]+):(\\d+):(?:\\d+:)? (warning|error): (.*)$" // GCC 4 warning
             + ")|("
-            + "(^make\\[.*\\]: Entering directory)\\s*(\\`((.*))\\')" // handle make entering directory
+            + "(^g?make\\[.*\\]: Entering directory)\\s*(\\`((.*))\\')" // handle make entering directory
             + ")";
     private String directory = "";
 


### PR DESCRIPTION
Hi Ulli,

I tried this new parser in the hope that it will fix JENKINS-14064 for me, but unfortunately, I was not able to get it to work, because my particular project invokes GNU Make as gmake and hence its messages are not recognized:

```
gmake[1]: Entering directory `/mnt/ram/workspace'
```

I came up with this simple fix (which I didn't test, though!) for your consideration. Please have a look and see if it makes sense...

Thanks,
--Yury.
