### PR TITLE
Fix NullPointerException coming from ViolationsAdapter

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/ViolationsAdapter.java
+++ b/src/main/java/hudson/plugins/warnings/parser/ViolationsAdapter.java
@@ -57,7 +57,7 @@ public class ViolationsAdapter extends AbstractWarningsParser {
         File temp = copyContentToTemporaryFile(reader);
 
         FullBuildModel model = new FullBuildModel();
-        parser.parse(model, temp.getParentFile(), temp.getName(), null);
+        parser.parse(model, temp.getParentFile(), temp.getName(), new String[] {});
 
         return convertToWarnings(model);
     }


### PR DESCRIPTION
This is the stack trace that I'm getting:

```
java.lang.NullPointerException
    at hudson.plugins.violations.util.AbsoluteFileFinder.addSourcePaths(AbsoluteFileFinder.java:20)
    at hudson.plugins.violations.types.pylint.PyLintParser.parse(PyLintParser.java:45)
    at hudson.plugins.warnings.parser.ViolationsAdapter.parse(ViolationsAdapter.java:60)
    at hudson.plugins.warnings.parser.ParserRegistry.parse(ParserRegistry.java:313)
    at hudson.plugins.warnings.parser.ParserRegistry.parse(ParserRegistry.java:292)
    at hudson.plugins.warnings.parser.FileWarningsParser.parse(FileWarningsParser.java:53)
    at hudson.plugins.analysis.core.FilesParser.parseFile(FilesParser.java:306)
    at hudson.plugins.analysis.core.FilesParser.parseFiles(FilesParser.java:264)
    at hudson.plugins.analysis.core.FilesParser.parserCollectionOfFiles(FilesParser.java:215)
    at hudson.plugins.analysis.core.FilesParser.invoke(FilesParser.java:184)
    at hudson.plugins.analysis.core.FilesParser.invoke(FilesParser.java:31)
    at hudson.FilePath.act(FilePath.java:906)
    at hudson.FilePath.act(FilePath.java:879)
    at hudson.plugins.warnings.WarningsPublisher.parseFiles(WarningsPublisher.java:430)
    at hudson.plugins.warnings.WarningsPublisher.perform(WarningsPublisher.java:317)
    at hudson.plugins.analysis.core.HealthAwareRecorder.perform(HealthAwareRecorder.java:331)
    at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:19)
    at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:804)
    at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:776)
    at hudson.model.Build$BuildExecution.post2(Build.java:183)
    at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:726)
    at hudson.model.Run.execute(Run.java:1618)
    at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:46)
    at hudson.model.ResourceController.execute(ResourceController.java:88)
    at hudson.model.Executor.run(Executor.java:247)
```
