### PR TITLE
JENKINS-21377 adapt to tycho-compiler-jdt 0.19.0

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/EclipseParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/EclipseParser.java
@@ -16,7 +16,7 @@ import hudson.plugins.analysis.util.model.Priority;
 @Extension
 public class EclipseParser extends RegexpDocumentParser {
     private static final long serialVersionUID = 425883472788422955L;
-    private static final String ANT_ECLIPSE_WARNING_PATTERN = "\\[?(WARNING|ERROR)\\]?\\s*(?:in)?\\s*(.*)(?:\\(at line\\s*(\\d+)\\)|:\\[(\\d+),).*(?:\\r?\\n[^\\^]*)+(?:\\r?\\n(.*)([\\^]+).*)\\r?\\n(?:\\s*\\[.*\\]\\s*)?(.*)";
+    private static final String ANT_ECLIPSE_WARNING_PATTERN = "\\[?(WARNING|ERROR)\\]?\\s*(?:in)?\\s*(.*)(?:\\(at line\\s*(\\d+)\\)|:\\[(\\d+)).*(?:\\r?\\n[^\\^]*)+(?:\\r?\\n(.*)([\\^]+).*)\\r?\\n(?:\\s*\\[.*\\]\\s*)?(.*)";
 
     /**
      * Creates a new instance of {@link EclipseParser}.

--- a/src/test/java/hudson/plugins/warnings/parser/EclipseParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/EclipseParserTest.java
@@ -21,11 +21,35 @@ import hudson.plugins.analysis.util.model.Priority;
  */
 public class EclipseParserTest extends AbstractEclipseParserTest {
     /**
+     * Parses a warning log with previously undetected warnings.
+     *
+     * @throws IOException
+     *      if the file could not be read
+     * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-21377">Issue 21377</a>
+     */
+    @Test
+    public void issue21377() throws IOException {
+        Collection<FileAnnotation> warnings = createParser().parse(openFile("issue21377.txt"));
+
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 1, warnings.size());
+
+        ParserResult result = new ParserResult(warnings);
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 1, result.getNumberOfAnnotations());
+
+        Iterator<FileAnnotation> iterator = warnings.iterator();
+        checkWarning(iterator.next(),
+                13,
+                "The method getOldValue() from the type SomeType is deprecated",
+                "/path/to/job/job-name/module/src/main/java/com/example/Example.java",
+                getType(), "", Priority.NORMAL);
+    }
+
+    /**
      * Parses a warning log with 2 previously undetected warnings.
      *
      * @throws IOException
      *      if the file could not be read
-     * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-13696">Issue 13696</a>
+     * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-13969">Issue 13969</a>
      */
     @Test
     public void issue13969() throws IOException {

--- a/src/test/resources/hudson/plugins/warnings/parser/issue21377.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/issue21377.txt
@@ -1,0 +1,6 @@
+[INFO] Compiling 5 source files to /path/to/job/job-name/module/target/classes
+[WARNING] /path/to/job/job-name/module/src/main/java/com/example/Example.java:[13]
+    something.getOldValue();
+              ^^^^^^^^^^^^^
+The method getOldValue() from the type SomeType is deprecated
+1 problem (1 warning)


### PR DESCRIPTION
This shall fix https://issues.jenkins-ci.org/browse/JENKINS-21377.
Adapted the parser regexp to work with both "[line, column]" and "[line]" as location specs in the Java warning. The latter will be generated by org.eclipse.tycho:tycho-compiler-jdt:0.19.0.
