### PR TITLE
Fix WarningsAnnotationsAggregator not aggregating

### DIFF
--- a/src/main/java/hudson/plugins/warnings/WarningsAnnotationsAggregator.java
+++ b/src/main/java/hudson/plugins/warnings/WarningsAnnotationsAggregator.java
@@ -61,12 +61,13 @@ public class WarningsAnnotationsAggregator extends MatrixAggregator {
         if (!actions.isEmpty()) {
             for (WarningsResultAction action : actions) {
                 if (!totalsPerParser.containsKey(action.getParser())) {
-                    WarningsResult result = action.getResult();
-                    ParserResult aggregation = new ParserResult();
-                    aggregation.addAnnotations(result.getAnnotations());
-                    aggregation.addModules(result.getModules());
-                    totalsPerParser.put(action.getParser(), aggregation);
+                    totalsPerParser.put(action.getParser(), new ParserResult());
                 }
+
+                ParserResult aggregation = totalsPerParser.get(action.getParser());
+                WarningsResult result = action.getResult();
+                aggregation.addAnnotations(result.getAnnotations());
+                aggregation.addModules(result.getModules());
             }
         }
         return true;


### PR DESCRIPTION
I've always been a bit confused at the aggregate warning report when doing a Jenkins build. It seemed like it only counted one run of the matrix. I finally snapped and went and looked at the code.

The section which actually adds the result to the aggregate is guarded by a containsKey on the results map. In other words it only allows adding one result per parser type.

This is fixed here. Thanks.
