### PR TITLE
Update pattern to support z/OS message format

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/XlcCompilerParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/XlcCompilerParser.java
@@ -18,7 +18,7 @@ public class XlcCompilerParser extends RegexpLineParser {
     private static final String XLC_WARNING_PATTERN = ANT_TASK + ".*((?:[A-Z]+|[0-9]+-)[0-9]+)* \\([USEWI]\\)\\s*(.*)$";
 
     private static final String XLC_WARNING_PATTERN_WITH_LINE = ANT_TASK + "\"?([^\"]*)\"?, line ([0-9]+)\\.[0-9]+:( (?:[A-Z]+|[0-9]+-)[0-9]+)? \\(([USEWI])\\)\\s*(.*)$";
-    private static final String XLC_WARNING_PATTERN_NO_LINE = ANT_TASK + "\\s*((?:[A-Z]+|[0-9]+-)[0-9]+)?:? \\(([USEWI])\\)( INFORMATION:)?\\s*(.*)$";
+    private static final String XLC_WARNING_PATTERN_NO_LINE = ANT_TASK + "\\s*((?:[A-Z]+|[0-9]+-)[0-9]+)?:? *\\(([USEWI])\\)( INFORMATION:)?\\s*(.*)$";
     private static final Pattern PATTERN_1 = Pattern.compile(XLC_WARNING_PATTERN_WITH_LINE);
     private static final Pattern PATTERN_2 = Pattern.compile(XLC_WARNING_PATTERN_NO_LINE);
 

--- a/src/main/java/hudson/plugins/warnings/parser/XlcCompilerParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/XlcCompilerParser.java
@@ -15,10 +15,10 @@ import hudson.plugins.analysis.util.model.Priority;
 @Extension
 public class XlcCompilerParser extends RegexpLineParser {
     private static final long serialVersionUID = 5490211629355204910L;
-    private static final String XLC_WARNING_PATTERN = ANT_TASK + ".*([0-9]+-[0-9]+)* \\([USEWI]\\)\\s*(.*)$";
+    private static final String XLC_WARNING_PATTERN = ANT_TASK + ".*((?:[A-Z]+|[0-9]+-)[0-9]+)* \\([USEWI]\\)\\s*(.*)$";
 
-    private static final String XLC_WARNING_PATTERN_WITH_LINE = ANT_TASK + "\"?([^\"]*)\"?, line ([0-9]+)\\.[0-9]+:( [0-9]+-[0-9]+)? \\(([USEWI])\\)\\s*(.*)$";
-    private static final String XLC_WARNING_PATTERN_NO_LINE = ANT_TASK + "\\s*([0-9]+-[0-9]+)?:? \\(([USEWI])\\)( INFORMATION:)?\\s*(.*)$";
+    private static final String XLC_WARNING_PATTERN_WITH_LINE = ANT_TASK + "\"?([^\"]*)\"?, line ([0-9]+)\\.[0-9]+:( (?:[A-Z]+|[0-9]+-)[0-9]+)? \\(([USEWI])\\)\\s*(.*)$";
+    private static final String XLC_WARNING_PATTERN_NO_LINE = ANT_TASK + "\\s*((?:[A-Z]+|[0-9]+-)[0-9]+)?:? \\(([USEWI])\\)( INFORMATION:)?\\s*(.*)$";
     private static final Pattern PATTERN_1 = Pattern.compile(XLC_WARNING_PATTERN_WITH_LINE);
     private static final Pattern PATTERN_2 = Pattern.compile(XLC_WARNING_PATTERN_NO_LINE);
 

--- a/src/main/java/hudson/plugins/warnings/parser/XlcCompilerParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/XlcCompilerParser.java
@@ -15,10 +15,10 @@ import hudson.plugins.analysis.util.model.Priority;
 @Extension
 public class XlcCompilerParser extends RegexpLineParser {
     private static final long serialVersionUID = 5490211629355204910L;
-    private static final String XLC_WARNING_PATTERN = ANT_TASK + ".*((?:[A-Z]+|[0-9]+-)[0-9]+)* \\([USEWI]\\)\\s*(.*)$";
+    private static final String XLC_WARNING_PATTERN = ANT_TASK + ".*((?:[A-Z]+|[0-9]+-)[0-9]+)* ?\\([USEWI]\\)\\s*(.*)$";
 
     private static final String XLC_WARNING_PATTERN_WITH_LINE = ANT_TASK + "\"?([^\"]*)\"?, line ([0-9]+)\\.[0-9]+:( (?:[A-Z]+|[0-9]+-)[0-9]+)? \\(([USEWI])\\)\\s*(.*)$";
-    private static final String XLC_WARNING_PATTERN_NO_LINE = ANT_TASK + "\\s*((?:[A-Z]+|[0-9]+-)[0-9]+)?:? *\\(([USEWI])\\)( INFORMATION:)?\\s*(.*)$";
+    private static final String XLC_WARNING_PATTERN_NO_LINE = ANT_TASK + "\\s*((?:[A-Z]+|[0-9]+-)[0-9]+)?:? ?\\(([USEWI])\\)( INFORMATION:)?\\s*(.*)$";
     private static final Pattern PATTERN_1 = Pattern.compile(XLC_WARNING_PATTERN_WITH_LINE);
     private static final Pattern PATTERN_2 = Pattern.compile(XLC_WARNING_PATTERN_NO_LINE);
 

--- a/src/test/java/hudson/plugins/warnings/parser/XlcParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/XlcParserTest.java
@@ -65,6 +65,30 @@ public class XlcParserTest extends ParserTester {
                 "1506-189",
                 Priority.HIGH);
     }
+    
+    /**
+     * Parses a string with xlC error in z/OS message format.
+     *
+     * @throws IOException
+     *      if IO error happened
+     */
+    @Test
+    public void testWarningsParserSevereError2() throws IOException {
+        Collection<FileAnnotation> warnings = new XlcCompilerParser().parse(
+                new StringReader("\"./Testapi.cpp\", line 4000.22: CCN5217 (S) \"AEUPD_RQ_UPDT\" is not a member of \"struct AEUPD_RQ\"."));
+
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 1, warnings.size());
+
+        Iterator<FileAnnotation> iterator = warnings.iterator();
+        FileAnnotation annotation = iterator.next();
+        checkWarning(annotation,
+                4000,
+                "\"AEUPD_RQ_UPDT\" is not a member of \"struct AEUPD_RQ\".",
+                "./Testapi.cpp",
+                TYPE,
+                "CCN5217",
+                Priority.HIGH);
+    }    
 
     /**
      * Parses a string with xlC error.
@@ -163,6 +187,54 @@ public class XlcParserTest extends ParserTester {
     }
 
     /**
+     * Parses a string with xlC warning message in z/OS format.
+     *
+     * @throws IOException
+     *      if IO error happened
+     */
+    @Test
+    public void testWarningsParserWarning2() throws IOException {
+        Collection<FileAnnotation> warnings = new XlcCompilerParser().parse(
+                new StringReader("\"./Testapi.cpp\", line 130.13: CCN5053 (W) The declaration of a class member within the class definition must not be qualified."));
+
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 1, warnings.size());
+
+        Iterator<FileAnnotation> iterator = warnings.iterator();
+        FileAnnotation annotation = iterator.next();
+        checkWarning(annotation,
+                130,
+                "The declaration of a class member within the class definition must not be qualified.",
+                "./Testapi.cpp",
+                TYPE,
+                "CCN5053",
+                Priority.NORMAL);
+    }
+
+    /**
+     * Parses a string with xlC warning message in z/OS format.
+     *
+     * @throws IOException
+     *      if IO error happened
+     */
+    @Test
+    public void testWarningsParserWarning3() throws IOException {
+        Collection<FileAnnotation> warnings = new XlcCompilerParser().parse(
+                new StringReader("CCN7504(W) \"//''\" is not a valid suboption for \"SEARCH\".  The option is ignored."));
+
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 1, warnings.size());
+
+        Iterator<FileAnnotation> iterator = warnings.iterator();
+        FileAnnotation annotation = iterator.next();
+        checkWarning(annotation,
+                0,
+                "\"//''\" is not a valid suboption for \"SEARCH\".  The option is ignored.",
+                "",
+                TYPE,
+                "CCN7504",
+                Priority.NORMAL);
+    }
+
+    /**
      * Parses a string with xlC informational message.
      *
      * @throws IOException
@@ -234,6 +306,53 @@ public class XlcParserTest extends ParserTester {
                 Priority.LOW);
     }
 
+    /**
+     * Parses a string with xlC informational message in z/OS format.
+     *
+     * @throws IOException
+     *      if IO error happened
+     */
+    @Test
+    public void testWarningsParserInfo4() throws IOException {
+        Collection<FileAnnotation> warnings = new XlcCompilerParser().parse(
+                new StringReader("\"./Testapi.cpp\", line 372.8: CCN6283 (I) \"Testapi::Test(long, long)\" is not a viable candidate."));
+
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 1, warnings.size());
+
+        Iterator<FileAnnotation> iterator = warnings.iterator();
+        FileAnnotation annotation = iterator.next();
+        checkWarning(annotation,
+                372,
+                "\"Testapi::Test(long, long)\" is not a viable candidate.",
+                "./Testapi.cpp",
+                TYPE,
+                "CCN6283",
+                Priority.LOW);
+    }
+
+    /**
+     * Parses a string with xlC informational message in z/OS format.
+     *
+     * @throws IOException
+     *      if IO error happened
+     */
+    @Test
+    public void testWarningsParserInfo5() throws IOException {
+        Collection<FileAnnotation> warnings = new XlcCompilerParser().parse(
+                new StringReader("CCN8151(I) The option \"TARGET(0x410D0000)\" sets \"ARCH(5)\"."));
+
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 1, warnings.size());
+
+        Iterator<FileAnnotation> iterator = warnings.iterator();
+        FileAnnotation annotation = iterator.next();
+        checkWarning(annotation,
+                0,
+                "The option \"TARGET(0x410D0000)\" sets \"ARCH(5)\".",
+                "",
+                TYPE,
+                "CCN8151",
+                Priority.LOW);
+    }
 
     @Override
     protected String getWarningsFile() {

--- a/src/test/java/hudson/plugins/warnings/parser/XlcParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/XlcParserTest.java
@@ -65,7 +65,7 @@ public class XlcParserTest extends ParserTester {
                 "1506-189",
                 Priority.HIGH);
     }
-    
+
     /**
      * Parses a string with xlC error in z/OS message format.
      *
@@ -73,7 +73,7 @@ public class XlcParserTest extends ParserTester {
      *      if IO error happened
      */
     @Test
-    public void testWarningsParserSevereError2() throws IOException {
+    public void testWarningsParserSevereErrorZOS() throws IOException {
         Collection<FileAnnotation> warnings = new XlcCompilerParser().parse(
                 new StringReader("\"./Testapi.cpp\", line 4000.22: CCN5217 (S) \"AEUPD_RQ_UPDT\" is not a member of \"struct AEUPD_RQ\"."));
 
@@ -88,7 +88,7 @@ public class XlcParserTest extends ParserTester {
                 TYPE,
                 "CCN5217",
                 Priority.HIGH);
-    }    
+    }
 
     /**
      * Parses a string with xlC error.
@@ -193,7 +193,7 @@ public class XlcParserTest extends ParserTester {
      *      if IO error happened
      */
     @Test
-    public void testWarningsParserWarning2() throws IOException {
+    public void testWarningsParserWarningZOS1() throws IOException {
         Collection<FileAnnotation> warnings = new XlcCompilerParser().parse(
                 new StringReader("\"./Testapi.cpp\", line 130.13: CCN5053 (W) The declaration of a class member within the class definition must not be qualified."));
 
@@ -217,7 +217,7 @@ public class XlcParserTest extends ParserTester {
      *      if IO error happened
      */
     @Test
-    public void testWarningsParserWarning3() throws IOException {
+    public void testWarningsParserWarningZOS2() throws IOException {
         Collection<FileAnnotation> warnings = new XlcCompilerParser().parse(
                 new StringReader("CCN7504(W) \"//''\" is not a valid suboption for \"SEARCH\".  The option is ignored."));
 
@@ -313,7 +313,7 @@ public class XlcParserTest extends ParserTester {
      *      if IO error happened
      */
     @Test
-    public void testWarningsParserInfo4() throws IOException {
+    public void testWarningsParserInfoZOS1() throws IOException {
         Collection<FileAnnotation> warnings = new XlcCompilerParser().parse(
                 new StringReader("\"./Testapi.cpp\", line 372.8: CCN6283 (I) \"Testapi::Test(long, long)\" is not a viable candidate."));
 
@@ -337,7 +337,7 @@ public class XlcParserTest extends ParserTester {
      *      if IO error happened
      */
     @Test
-    public void testWarningsParserInfo5() throws IOException {
+    public void testWarningsParserInfoZOS2() throws IOException {
         Collection<FileAnnotation> warnings = new XlcCompilerParser().parse(
                 new StringReader("CCN8151(I) The option \"TARGET(0x410D0000)\" sets \"ARCH(5)\"."));
 


### PR DESCRIPTION
The IBM XL C++ message format for z/OS has capital letters in front (e.g. CCNnnnn, EDCnnnn etc).