### PR TITLE
Enriched the Puppet Lint parser with the ability to understand Windows paths

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/PuppetLintParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/PuppetLintParser.java
@@ -20,8 +20,11 @@ public class PuppetLintParser extends RegexpLineParser {
     private static final String SEPARATOR = "::";
 
     /** Pattern of puppet-lint compiler warnings. */
-    private static final String PUPPET_LINT_PATTERN_WARNING = "^\\s*([^:]+):([0-9]+):([^:]+):((?:WARNING)|(?:ERROR)):\\s*(.*)$";
-    private static final String PUPPET_LINT_PATTERN_PACKAGE = "^(.*/?modules/)?([^/]*)/manifests(.*)?(/([^/]*)\\.pp)$";
+    private static final String PUPPET_LINT_PATTERN_WARNING =
+        "^\\s*((?:[A-Za-z]:)?[^:]+):([0-9]+):([^:]+):((?:WARNING)|(?:ERROR)):\\s*(.*)$";
+
+    private static final String PUPPET_LINT_PATTERN_PACKAGE =
+        "^(.*/?modules/)?([^/]*)/manifests(.*)?(/([^/]*)\\.pp)$";
 
     private final Pattern packagePattern;
 
@@ -79,4 +82,3 @@ public class PuppetLintParser extends RegexpLineParser {
         return StringUtils.EMPTY;
     }
 }
-

--- a/src/test/java/hudson/plugins/warnings/parser/PuppetLintParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/PuppetLintParserTest.java
@@ -28,7 +28,7 @@ public class PuppetLintParserTest extends ParserTester {
     @Test
     public void testParse() throws IOException {
         Collection<FileAnnotation> results = createParser().parse(openFile());
-        assertEquals(3, results.size());
+        assertEquals(5, results.size());
 
         Iterator<FileAnnotation> iterator = results.iterator();
 
@@ -46,6 +46,16 @@ public class PuppetLintParserTest extends ParserTester {
         checkLintWarning(annotation,
                 10, "line has more than 80 characters",
                 "./modules/test/manifests/sub/class/morefail.pp", TYPE, "80chars", Priority.NORMAL, "::test::sub::class");
+
+        annotation = iterator.next();
+        checkLintWarning(annotation,
+                4, "tab character found",
+                "C:/ProgramData/PuppetLabs/puppet/etc/manifests/site.pp", TYPE, "hard_tabs", Priority.HIGH, "-");
+
+        annotation = iterator.next();
+        checkLintWarning(annotation,
+                15, "line has more than 80 characters",
+                "C:/CI CD/puppet/modules/jenkins/init.pp", TYPE, "80chars", Priority.NORMAL, "-");
     }
 
     /**

--- a/src/test/resources/hudson/plugins/warnings/parser/puppet-lint.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/puppet-lint.txt
@@ -1,3 +1,7 @@
+ -------------------------------------------------------------------------------
+| Linux |
+ -------
+
 failtest.pp:1:autoloader_layout:ERROR:failtest not in autoload module layout
 ./modules/test/manifests/init.pp:3:80chars:WARNING:line has more than 80 characters
 ./modules/test/manifests/sub/class/morefail.pp:10:80chars:WARNING:line has more than 80 characters
@@ -9,3 +13,11 @@ Ubuntu
 
     ubuntu-server-1404-x64 13:48:01$ env PATH="/usr/bin:/opt/puppet-git-repos/hiera/bin:${PATH}" RUBYLIB="/opt/puppet-git-repos/hiera/lib:/opt/puppet-git-repos/hiera-puppet/lib:${RUBYLIB}" facter  osfamily
     Debian
+
+
+ -------------------------------------------------------------------------------
+| Windows |
+ ---------
+
+C:\ProgramData\PuppetLabs\puppet\etc\manifests\site.pp:4:hard_tabs:ERROR:tab character found
+C:\CI CD\puppet\modules\jenkins\init.pp:15:80chars:WARNING:line has more than 80 characters


### PR DESCRIPTION
This change addresses only the PUPPET_LINT_PATTERN_WARNING regular expression's shortcomings.