### PR TITLE
Adjust priorities in PylintParser

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/PyLintParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/PyLintParser.java
@@ -37,11 +37,30 @@ public class PyLintParser extends RegexpLineParser {
         String message = matcher.group(4);
         String category = classifyIfEmpty(matcher.group(3), message);
         //First letter of the Pylint classification is one of F/E/W/R/C. E/F/W are high priority.
-        Priority priority = Priority.NORMAL;
-        if (category.charAt(0) == 'E' || category.charAt(0) == 'F' || category.charAt(0) == 'W') {
-            priority = Priority.HIGH;
-        }
+        Priority priority = Priority.LOW;
+
+        // See http://docs.pylint.org/output.html for definitions of the categories
+        switch (category.charAt(0)) {
+          // [R]efactor for a “good practice” metric violation
+          // [C]onvention for coding standard violation
+        case 'R':
+        case 'C':
+          priority = Priority.LOW;
+        break;
         
+        // [W]arning for stylistic problems, or minor programming issues
+        case 'W':
+          priority = Priority.NORMAL;
+          break;
+          
+          // [E]rror for important programming issues (i.e. most probably bug)
+          // [F]atal for errors which prevented further processing
+        case 'E':
+        case 'F':
+          priority = Priority.HIGH;
+        break;
+        }
+
         return createWarning(matcher.group(1), getLineNumber(matcher.group(2)), category, message, priority);
     }
 }

--- a/src/test/java/hudson/plugins/warnings/parser/PylintParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/PylintParserTest.java
@@ -38,21 +38,21 @@ public class PylintParserTest extends ParserTester {
                 3,
                 "Line too long (85/80)",
                 "trunk/src/python/cachedhttp.py",
-                WARNING_TYPE, "C", Priority.NORMAL);
+                WARNING_TYPE, "C", Priority.LOW);
 
         warning = iterator.next();
         checkWarning(warning,
                 28,
                 "Invalid name \"seasonCount\" (should match [a-z_][a-z0-9_]{2,30}$)",
                 "trunk/src/python/tv.py",
-                WARNING_TYPE, "C0103", Priority.NORMAL);
+                WARNING_TYPE, "C0103", Priority.LOW);
 
         warning = iterator.next();
         checkWarning(warning,
                 35,
                 "Missing docstring",
                 "trunk/src/python/tv.py",
-                WARNING_TYPE, "C0111", Priority.NORMAL);
+                WARNING_TYPE, "C0111", Priority.LOW);
                 
         warning = iterator.next();
         checkWarning(warning,
@@ -73,7 +73,7 @@ public class PylintParserTest extends ParserTester {
                 39,
                 "Dangerous default value \"[]\" as argument",
                 "trunk/src/python/tv.py",
-                WARNING_TYPE, "W0102", Priority.HIGH);
+                WARNING_TYPE, "W0102", Priority.NORMAL);
     }
 
     @Override


### PR DESCRIPTION
According to http://docs.pylint.org/output.html, the PyLint classifications are:

    [R]efactor for a “good practice” metric violation
    [C]onvention for coding standard violation
    [W]arning for stylistic problems, or minor programming issues
    [E]rror for important programming issues (i.e. most probably bug)
    [F]atal for errors which prevented further processing

Currently, the warnings plugin reports warnings as high priority; this includes "TODO:" items.  This means that "most probably bug"s are being grouped together with stylistic problems.  Also, low priority seems to be unused.  In this pull request, change the mapping to:

    Low: R, C
    Medium: W
    High: E, F
