### PR TITLE
[JENKINS-29959] Make Warnings Plugin compatible with Workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /target/
 /work/
 .DS_Store
-/target
 /npm-debug.log
 /Plug-Ins
+
+.idea
+/warnings.iml

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>1.59</version>
+    <version>1.63</version>
   </parent>
 
   <artifactId>warnings</artifactId>
@@ -15,6 +15,10 @@
   <description>This plug-in reads the compiler warnings from the
     console log file and generates a trend report.
   </description>
+
+  <properties>
+    <workflow-jenkins-plugin.version>1.4</workflow-jenkins-plugin.version>
+  </properties>
 
   <licenses>
     <license>
@@ -51,7 +55,7 @@
     <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>
       <artifactId>analysis-core</artifactId>
-      <version>1.73-SNAPSHOT</version>
+      <version>1.73-beta-SNAPSHOT</version><!-- TODO: change to 1.73 before release -->
     </dependency>
     <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>
@@ -74,6 +78,12 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-digester3</artifactId>
       <version>3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-aggregator</artifactId>
+      <version>${workflow-jenkins-plugin.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/hudson/plugins/warnings/AggregatedWarningsResult.java
+++ b/src/main/java/hudson/plugins/warnings/AggregatedWarningsResult.java
@@ -4,6 +4,7 @@ import com.thoughtworks.xstream.XStream;
 
 import hudson.model.AbstractBuild;
 
+import hudson.model.Run;
 import hudson.plugins.analysis.core.BuildHistory;
 import hudson.plugins.analysis.core.ParserResult;
 import hudson.plugins.analysis.core.ResultAction;
@@ -31,8 +32,29 @@ public class AggregatedWarningsResult extends BuildResult {
      *            the parsed result with all annotations
      * @param defaultEncoding
      *            the default encoding to be used when reading and parsing files
+     *
+     * @deprecated see {@link #AggregatedWarningsResult(Run, BuildHistory, ParserResult, String)}
      */
+    @Deprecated
     public AggregatedWarningsResult(final AbstractBuild<?, ?> build, final BuildHistory history, final ParserResult result,
+            final String defaultEncoding) {
+        this((Run<?, ?>) build, history, result, defaultEncoding);
+
+    }
+
+    /**
+     * Creates a new instance of {@link AggregatedWarningsResult}.
+     *
+     * @param build
+     *            the current build as owner of this action
+     * @param history
+     *            build history
+     * @param result
+     *            the parsed result with all annotations
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     */
+    public AggregatedWarningsResult(final Run<?, ?> build, final BuildHistory history, final ParserResult result,
             final String defaultEncoding) {
         super(build, history, result, defaultEncoding);
 

--- a/src/main/java/hudson/plugins/warnings/AggregatedWarningsResultAction.java
+++ b/src/main/java/hudson/plugins/warnings/AggregatedWarningsResultAction.java
@@ -2,6 +2,7 @@ package hudson.plugins.warnings;
 
 import hudson.model.AbstractBuild;
 
+import hudson.model.Run;
 import hudson.plugins.analysis.core.NullHealthDescriptor;
 import hudson.plugins.analysis.core.AbstractResultAction;
 import hudson.plugins.analysis.core.PluginDescriptor;
@@ -23,8 +24,23 @@ public class AggregatedWarningsResultAction extends AbstractResultAction<Aggrega
      *            the associated build of this action
      * @param result
      *            the result in this build
+     *
+     * @deprecated see {@link #AggregatedWarningsResultAction(Run, AggregatedWarningsResult)}
      */
+    @Deprecated
     public AggregatedWarningsResultAction(final AbstractBuild<?, ?> owner, final AggregatedWarningsResult result) {
+        this((Run<? ,?>) owner, result);
+    }
+
+    /**
+     * Creates a new instance of <code>WarningsResultAction</code>.
+     *
+     * @param owner
+     *            the associated build of this action
+     * @param result
+     *            the result in this build
+     */
+    public AggregatedWarningsResultAction(final Run<?, ?> owner, final AggregatedWarningsResult result) {
         super(owner, NULL_HEALTH_DESCRIPTOR, result);
     }
 

--- a/src/main/java/hudson/plugins/warnings/WarningsBuildHistory.java
+++ b/src/main/java/hudson/plugins/warnings/WarningsBuildHistory.java
@@ -4,6 +4,7 @@ import javax.annotation.CheckForNull;
 import java.util.List;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.plugins.analysis.core.BuildHistory;
 
 /**
@@ -27,16 +28,55 @@ public class WarningsBuildHistory extends BuildHistory {
      * @param useStableBuildAsReference
      *            determines whether only stable builds should be used as
      *            reference builds or not
+     *
+     * @deprecated see {@link #WarningsBuildHistory(Run, String, boolean, boolean)}
      */
+    @Deprecated
     public WarningsBuildHistory(final AbstractBuild<?, ?> lastFinishedBuild, @CheckForNull final String group,
             final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference) {
+        this((Run<?, ?>) lastFinishedBuild, group, usePreviousBuildAsReference, useStableBuildAsReference);
+    }
+
+    /**
+     * Creates a new instance of {@link WarningsBuildHistory}.
+     *
+     * @param lastFinishedBuild
+     *            the last finished build
+     * @param group
+     *            the parser group
+     * @param usePreviousBuildAsReference
+     *            determines whether to use the previous build as the reference
+     *            build
+     * @param useStableBuildAsReference
+     *            determines whether only stable builds should be used as
+     *            reference builds or not
+     */
+    public WarningsBuildHistory(final Run<?, ?> lastFinishedBuild, @CheckForNull final String group,
+                                final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference) {
         super(lastFinishedBuild, WarningsResultAction.class, usePreviousBuildAsReference, useStableBuildAsReference);
 
         this.group = group;
     }
 
     @Override
+    @Deprecated
     public WarningsResultAction getResultAction(final AbstractBuild<?, ?> build) {
+        List<WarningsResultAction> actions = build.getActions(WarningsResultAction.class);
+        if (group != null) {
+            for (WarningsResultAction action : actions) {
+                if (group.equals(action.getParser())) {
+                    return action;
+                }
+            }
+        }
+        if (!actions.isEmpty() && actions.get(0).getParser() == null) { // fallback 3.x
+            return actions.get(0);
+        }
+        return null;
+    }
+
+    @Override
+    public WarningsResultAction getResultAction(final Run<?, ?> build) {
         List<WarningsResultAction> actions = build.getActions(WarningsResultAction.class);
         if (group != null) {
             for (WarningsResultAction action : actions) {

--- a/src/main/java/hudson/plugins/warnings/WarningsPublisher.java
+++ b/src/main/java/hudson/plugins/warnings/WarningsPublisher.java
@@ -8,6 +8,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import hudson.FilePath;
+import hudson.model.Action;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -18,10 +24,6 @@ import hudson.Launcher;
 import hudson.Util;
 import hudson.matrix.MatrixAggregator;
 import hudson.matrix.MatrixBuild;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.Action;
-import hudson.model.BuildListener;
 import hudson.plugins.analysis.core.AnnotationsClassifier;
 import hudson.plugins.analysis.core.BuildHistory;
 import hudson.plugins.analysis.core.BuildResult;
@@ -49,9 +51,9 @@ public class WarningsPublisher extends HealthAwarePublisher {
     private static final long serialVersionUID = -5936973521277401764L;
 
     /** Ant file-set pattern of files to include to report. */
-    private final String includePattern;
+    private String includePattern;
     /** Ant file-set pattern of files to exclude from report. */
-    private final String excludePattern;
+    private String excludePattern;
 
     /** File pattern and parser configurations. @since 3.19 */
     @edu.umd.cs.findbugs.annotations.SuppressWarnings("SE")
@@ -134,10 +136,12 @@ public class WarningsPublisher extends HealthAwarePublisher {
      *            the parser configurations to scan files
      * @param consoleParsers
      *            the parsers to scan the console
+     *
+     * @deprecated see {@link #WarningsPublisher(List, List)}}
      */
     // CHECKSTYLE:OFF
     @SuppressWarnings("PMD.ExcessiveParameterList")
-    @DataBoundConstructor
+    @Deprecated
     public WarningsPublisher(final String healthy, final String unHealthy, final String thresholdLimit,
             final String defaultEncoding, final boolean useDeltaValues,
             final String unstableTotalAll, final String unstableTotalHigh, final String unstableTotalNormal, final String unstableTotalLow,
@@ -164,6 +168,18 @@ public class WarningsPublisher extends HealthAwarePublisher {
         }
     }
     // CHECKSTYLE:ON
+
+    @DataBoundConstructor
+    public WarningsPublisher(final List<ConsoleParser> consoleParsers, final List<ParserConfiguration> parserConfigurations) {
+        super(PLUGIN_NAME);
+
+        if (consoleParsers != null) {
+            this.consoleParsers.addAll(consoleParsers);
+        }
+        if (parserConfigurations != null) {
+            this.parserConfigurations.addAll(parserConfigurations);
+        }
+    }
 
     /**
      * Returns the names of the configured parsers for the console log.
@@ -313,15 +329,15 @@ public class WarningsPublisher extends HealthAwarePublisher {
     }
 
     @Override
-    protected BuildResult perform(final AbstractBuild<?, ?> build, final PluginLogger logger)
+    protected BuildResult perform(final Run<?, ?> build, final FilePath workspace, final PluginLogger logger)
             throws InterruptedException, IOException {
         try {
             if (!hasConsoleParsers() && !hasFileParsers()) {
                 throw new IOException("Error: No warning parsers defined in the job configuration.");
             }
 
-            List<ParserResult> fileResults = parseFiles(build, logger);
-            List<ParserResult> consoleResults = parseConsoleLog(build, logger);
+            List<ParserResult> fileResults = parseFiles(build, workspace, logger);
+            List<ParserResult> consoleResults = parseConsoleLog(build, workspace, logger);
 
             ParserResult totals = new ParserResult();
             add(totals, consoleResults);
@@ -342,7 +358,7 @@ public class WarningsPublisher extends HealthAwarePublisher {
         }
     }
 
-    private BuildResult emptyBuildResult(final AbstractBuild<?, ?> build, final PluginLogger logger, final Exception exception) {
+    private BuildResult emptyBuildResult(final Run<?, ?> build, final PluginLogger logger, final Exception exception) {
         logger.log(exception.getMessage());
 
         return new AggregatedWarningsResult(build, new NullBuildHistory(), new ParserResult(), getDefaultEncoding());
@@ -372,8 +388,8 @@ public class WarningsPublisher extends HealthAwarePublisher {
         }
     }
 
-    private List<ParserResult> parseConsoleLog(final AbstractBuild<?, ?> build,
-            final PluginLogger logger) throws IOException, InterruptedException {
+    private List<ParserResult> parseConsoleLog(final Run<?, ?> build, final FilePath workspace, final PluginLogger logger)
+            throws IOException, InterruptedException {
         List<ParserResult> results = Lists.newArrayList();
         for (ConsoleParser parser : getConsoleParsers()) {
             String parserName = parser.getParserName();
@@ -381,13 +397,13 @@ public class WarningsPublisher extends HealthAwarePublisher {
 
             Collection<FileAnnotation> warnings = new ParserRegistry(ParserRegistry.getParsers(parserName),
                     getDefaultEncoding()).parse(build.getLogFile());
-            if (!build.getWorkspace().isRemote()) {
-                guessModuleNames(build, warnings);
+            if (!workspace.isRemote()) {
+                guessModuleNames(workspace, warnings);
             }
-            ParserResult project = new ParserResult(build.getWorkspace(), canResolveRelativePaths());
+            ParserResult project = new ParserResult(workspace, canResolveRelativePaths());
             project.addAnnotations(warnings);
 
-            results.add(annotate(build, filterWarnings(project, logger), parserName));
+            results.add(annotate(build, workspace, filterWarnings(project, logger), parserName));
         }
         return results;
     }
@@ -402,16 +418,15 @@ public class WarningsPublisher extends HealthAwarePublisher {
         return project;
     }
 
-    private void guessModuleNames(final AbstractBuild<?, ?> build, final Collection<FileAnnotation> warnings) {
-        String workspace = build.getWorkspace().getRemote();
-        ModuleDetector detector = createModuleDetector(workspace);
+    private void guessModuleNames(final FilePath workspace, final Collection<FileAnnotation> warnings) {
+        ModuleDetector detector = createModuleDetector(workspace.getRemote());
         for (FileAnnotation annotation : warnings) {
             String module = detector.guessModuleName(annotation.getFileName());
             annotation.setModuleName(module);
         }
     }
 
-    private List<ParserResult> parseFiles(final AbstractBuild<?, ?> build, final PluginLogger logger)
+    private List<ParserResult> parseFiles(final Run<?, ?> build, final FilePath workspace, final PluginLogger logger)
             throws IOException, InterruptedException {
         List<ParserResult> results = Lists.newArrayList();
         for (ParserConfiguration configuration : getParserConfigurations()) {
@@ -423,11 +438,11 @@ public class WarningsPublisher extends HealthAwarePublisher {
             FilesParser parser = new FilesParser(PLUGIN_NAME, filePattern,
                     new FileWarningsParser(ParserRegistry.getParsers(parserName), getDefaultEncoding()),
                     shouldDetectModules(), isMavenBuild(build), canResolveRelativePaths());
-            ParserResult project = build.getWorkspace().act(parser);
+            ParserResult project = workspace.act(parser);
             logger.logLines(project.getLogMessages());
 
             returnIfCanceled();
-            results.add(annotate(build, filterWarnings(project, logger), configuration.getParserName()));
+            results.add(annotate(build, workspace, filterWarnings(project, logger), configuration.getParserName()));
         }
         return results;
     }
@@ -435,10 +450,10 @@ public class WarningsPublisher extends HealthAwarePublisher {
     /**
      * Resolve build parameters in the file pattern up to resolveDepth times.
      */
-    private String expandFilePattern(final AbstractBuild<?, ?> build, final String filePattern) {
+    private String expandFilePattern(final Run<?, ?> build, final String filePattern) throws IOException, InterruptedException {
         String expanded = filePattern;
         int resolveDepth = 10;
-        Map<String, String> buildParameterMap = build.getBuildVariables();
+        Map<String, String> buildParameterMap = build.getEnvironment(TaskListener.NULL);
         for (int i = 0; i < resolveDepth; i++) {
             String old = expanded;
             expanded = Util.replaceMacro(expanded, buildParameterMap);
@@ -449,11 +464,11 @@ public class WarningsPublisher extends HealthAwarePublisher {
         return expanded;
     }
 
-    private ParserResult annotate(final AbstractBuild<?, ?> build, final ParserResult input, final String parserName)
+    private ParserResult annotate(final Run<?, ?> build, final FilePath workspace, final ParserResult input, final String parserName)
             throws IOException, InterruptedException {
-        ParserResult output = build.getWorkspace().act(new AnnotationsClassifier(input, getDefaultEncoding()));
+        ParserResult output = workspace.act(new AnnotationsClassifier(input, getDefaultEncoding()));
         for (FileAnnotation annotation : output.getAnnotations()) {
-            annotation.setPathName(build.getWorkspace().getRemote());
+            annotation.setPathName(workspace.getRemote());
         }
         WarningsBuildHistory history = new WarningsBuildHistory(build, parserName,
                 usePreviousBuildAsReference(), useOnlyStableBuildsAsReference());

--- a/src/main/java/hudson/plugins/warnings/WarningsResult.java
+++ b/src/main/java/hudson/plugins/warnings/WarningsResult.java
@@ -6,6 +6,7 @@ import com.thoughtworks.xstream.XStream;
 
 import hudson.model.AbstractBuild;
 
+import hudson.model.Run;
 import hudson.plugins.analysis.core.BuildHistory;
 import hudson.plugins.analysis.core.ParserResult;
 import hudson.plugins.analysis.core.ResultAction;
@@ -41,15 +42,43 @@ public class WarningsResult extends BuildResult {
      *            the default encoding to be used when reading and parsing files
      * @param group
      *            the parser group this result belongs to
+     *
+     * @deprecated see {@link #WarningsResult(Run, BuildHistory, ParserResult, String, String)}
      */
+    @Deprecated
     public WarningsResult(final AbstractBuild<?, ?> build, final BuildHistory history,
+            final ParserResult result, final String defaultEncoding, final String group) {
+        this((Run<?, ?>) build, history, result, defaultEncoding, group, group == null ? false : true);
+    }
+
+    /**
+     * Creates a new instance of {@link WarningsResult}.
+     *
+     * @param build
+     *            the current build as owner of this action
+     * @param history
+     *            the build history
+     * @param result
+     *            the parsed result with all annotations
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param group
+     *            the parser group this result belongs to
+     */
+    public WarningsResult(final Run<?, ?> build, final BuildHistory history,
             final ParserResult result, final String defaultEncoding, final String group) {
         this(build, history, result, defaultEncoding, group, group == null ? false : true);
     }
 
+    @Deprecated
     WarningsResult(final AbstractBuild<?, ?> build, final BuildHistory history,
             final ParserResult result, final String defaultEncoding,
             final String group, final boolean canSerialize) {
+        this((Run<?, ?>) build, history, result, defaultEncoding, group, canSerialize);
+    }
+
+    WarningsResult(final Run<?, ?> build, final BuildHistory history, final ParserResult result,
+            final String defaultEncoding, final String group, final boolean canSerialize) {
         super(build, history, result, defaultEncoding);
 
         this.group = group;
@@ -58,8 +87,14 @@ public class WarningsResult extends BuildResult {
         }
     }
 
+    @Deprecated
     @Override
     protected BuildHistory createHistory(final AbstractBuild<?, ?> build) {
+        return new WarningsBuildHistory((Run<?, ?>) build, group, false, false);
+    }
+
+    @Override
+    protected BuildHistory createHistory(final Run<?, ?> build) {
         return new WarningsBuildHistory(build, group, false, false);
     }
 

--- a/src/main/java/hudson/plugins/warnings/WarningsResultAction.java
+++ b/src/main/java/hudson/plugins/warnings/WarningsResultAction.java
@@ -1,5 +1,6 @@
 package hudson.plugins.warnings;
 
+import hudson.model.Run;
 import org.jvnet.localizer.Localizable;
 
 import hudson.model.AbstractBuild;
@@ -33,8 +34,26 @@ public class WarningsResultAction extends AbstractResultAction<WarningsResult> {
      * @param result
      *            the result in this build
      * @param parserName the name of the parser
+     *
+     * @deprecated see {@link #WarningsResultAction(Run, HealthDescriptor, WarningsResult, String)}
      */
+    @Deprecated
     public WarningsResultAction(final AbstractBuild<?, ?> owner, final HealthDescriptor healthDescriptor, final WarningsResult result, final String parserName) {
+        this((Run<?, ?>) owner, new WarningsHealthDescriptor(healthDescriptor, ParserRegistry.getParser(parserName).getParserName()), result, parserName);
+    }
+
+    /**
+     * Creates a new instance of <code>WarningsResultAction</code>.
+     *
+     * @param owner
+     *            the associated build of this action
+     * @param healthDescriptor
+     *            health descriptor to use
+     * @param result
+     *            the result in this build
+     * @param parserName the name of the parser
+     */
+    public WarningsResultAction(final Run<?, ?> owner, final HealthDescriptor healthDescriptor, final WarningsResult result, final String parserName) {
         super(owner, new WarningsHealthDescriptor(healthDescriptor, ParserRegistry.getParser(parserName).getParserName()), result);
 
         this.parserName = parserName;

--- a/src/main/java/hudson/plugins/warnings/parser/ParserRegistry.java
+++ b/src/main/java/hudson/plugins/warnings/parser/ParserRegistry.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BOMInputStream;
 import org.apache.commons.lang.StringUtils;
@@ -52,7 +53,7 @@ public class ParserRegistry {
      */
     @SuppressWarnings("javadoc")
     private static List<AbstractWarningsParser> all() {
-        Hudson instance = Hudson.getInstance();
+        Jenkins instance = Jenkins.getInstance();
         if (instance == null) {
             return Lists.newArrayList();
         }
@@ -63,7 +64,7 @@ public class ParserRegistry {
     }
 
     @SuppressWarnings("deprecation")
-    private static void addParsersWithDeprecatedApi(final Hudson instance, final List<AbstractWarningsParser> parsers) {
+    private static void addParsersWithDeprecatedApi(final Jenkins instance, final List<AbstractWarningsParser> parsers) {
         for (WarningsParser parser : instance.getExtensionList(WarningsParser.class)) {
             if (!(parser instanceof AbstractWarningsParser)) {
                 parsers.add(new ParserAdapter(parser));

--- a/src/test/java/hudson/plugins/warnings/WarningsWorkflowTest.java
+++ b/src/test/java/hudson/plugins/warnings/WarningsWorkflowTest.java
@@ -1,0 +1,79 @@
+package hudson.plugins.warnings;
+
+import hudson.FilePath;
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertEquals;
+
+public class WarningsWorkflowTest {
+
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    /**
+     * Run a workflow job using {@link WarningsPublisher} and check for success.
+     */
+    @Test
+    public void warningsPublisherWorkflowStep() throws Exception {
+        WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "warningsPublisherWorkflowStep");
+        FilePath workspace = jenkinsRule.jenkins.getWorkspaceFor(job);
+        FilePath report = workspace.child("target").child("maven.txt");
+        report.copyFrom(WarningsWorkflowTest.class.getResourceAsStream("/hudson/plugins/warnings/parser/maven.txt"));
+        job.setDefinition(new CpsFlowDefinition(""
+                        + "node {\n"
+                        + "  step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Maven', pattern: '**/maven.txt']]])\n"
+                        + "}\n", true)
+        );
+        jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0));
+        WarningsResultAction result = job.getLastBuild().getAction(WarningsResultAction.class);
+        assertEquals(5, result.getResult().getAnnotations().size());
+    }
+
+    /**
+     * Run a workflow job using {@link WarningsPublisher} with a failing threshold of 0, so the given example file
+     * "/hudson/plugins/warnings/parser/maven.txt" will make the build to fail.
+     */
+    @Test
+    public void warningsPublisherWorkflowStepSetLimits() throws Exception {
+        WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "warningsPublisherWorkflowStepSetLimits");
+        FilePath workspace = jenkinsRule.jenkins.getWorkspaceFor(job);
+        FilePath report = workspace.child("target").child("maven.txt");
+        report.copyFrom(WarningsWorkflowTest.class.getResourceAsStream("/hudson/plugins/warnings/parser/maven.txt"));
+        job.setDefinition(new CpsFlowDefinition(""
+                        + "node {\n"
+                        + "  step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Maven', pattern:" +
+                        " '**/maven.txt']], failedTotalAll: '0', usePreviousBuildAsReference: false])\n"
+                        + "}\n", true)
+        );
+        jenkinsRule.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get());
+        WarningsResultAction result = job.getLastBuild().getAction(WarningsResultAction.class);
+        assertEquals(5, result.getResult().getAnnotations().size());
+    }
+
+    /**
+     * Run a workflow job using {@link WarningsPublisher} with a unstable threshold of 0, so the given example file
+     * "/hudson/plugins/warnings/parser/maven.txt" will make the build to fail.
+     */
+    @Test
+    public void warningsPublisherWorkflowStepFailure() throws Exception {
+        WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "warningsPublisherWorkflowStepFailure");
+        FilePath workspace = jenkinsRule.jenkins.getWorkspaceFor(job);
+        FilePath report = workspace.child("target").child("maven.txt");
+        report.copyFrom(WarningsWorkflowTest.class.getResourceAsStream
+                ("/hudson/plugins/warnings/parser/maven.txt"));
+        job.setDefinition(new CpsFlowDefinition(""
+                        + "node {\n"
+                        + "  step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Maven', pattern:" +
+                        " '**/maven.txt']], unstableTotalAll: '0', usePreviousBuildAsReference: false])\n"
+                        + "}\n")
+        );
+        jenkinsRule.assertBuildStatus(Result.UNSTABLE, job.scheduleBuild2(0).get());
+        WarningsResultAction result = job.getLastBuild().getAction(WarningsResultAction.class);
+        assertEquals(5, result.getResult().getAnnotations().size());
+    }
+}


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/analysis-core-plugin/pull/31

Make Warnings Plugin compatible with Workflow [JENKINS-29959](https://wiki.jenkins-ci.org/display/JENKINS/Warnings+Plugin)

```
node {
  checkout changelog: false, poll: false, scm: [$class: 'SubversionSCM', additionalCredentials: [], excludedCommitMessages: '', excludedRegions: '', excludedRevprop: '', excludedUsers: '', filterChangelog: false, ignoreDirPropChanges: false, includedRegions: '', locations: [[credentialsId: 'efaa090d-5627-4a5c-95df-f570850d89a1', depthOption: 'infinity', ignoreExternalsOption: true, local: '.', remote: 'https://server/svn/repo/trunk']], workspaceUpdater: [$class: 'UpdateUpdater']]
  sh 'mvn clean install -Dmaven.test.skip'
  step([$class: 'WarningsPublisher', consoleParsers: [[parserName: 'Maven']]])
}
```

```
node {
  step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Maven', pattern: '**/maven.txt']]])
}
```


- [x] Initial source code modifications
- [x] Add an automated test specific for Workflow compatibility