### PR TITLE
Fix regex for Solaris Studio warnings

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/SunCParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/SunCParser.java
@@ -15,7 +15,7 @@ import hudson.plugins.analysis.util.model.Priority;
 public class SunCParser extends RegexpLineParser {
     private static final long serialVersionUID = -1251248150596418456L;
 
-    private static final String SUN_CPP_WARNING_PATTERN = "^\\s*\"(.*)\"\\s*,\\s*line\\s*(\\d+)\\s*:\\s*(Warning|Error)\\s*(?:, \\s*(.*))?\\s*:\\s*(.*)$";
+    private static final String SUN_CPP_WARNING_PATTERN = "^\\s*\"(.*)\"\\s*,\\s*line\\s*(\\d+)\\s*:\\s*(Warning|Error)(?:| .Anachronism.)\\s*(?:, \\s*([^:]*))?\\s*:\\s*(.*)$";
 
     /**
      * Creates a new instance of <code>HpiCompileParser</code>.

--- a/src/test/java/hudson/plugins/warnings/parser/SunCParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/SunCParserTest.java
@@ -20,7 +20,7 @@ public class SunCParserTest extends ParserTester {
     private static final String CATEGORY = "badargtypel2w";
 
     /**
-     * Parses a file with 5 warnings.
+     * Parses a file with 7 warnings.
      *
      * @throws IOException
      *      if the file could not be read
@@ -29,7 +29,7 @@ public class SunCParserTest extends ParserTester {
     public void parseSunCpp() throws IOException {
         Collection<FileAnnotation> warnings = new SunCParser().parse(openFile());
 
-        assertEquals("Wrong number of warnings detected.", 5, warnings.size());
+        assertEquals("Wrong number of warnings detected.", 7, warnings.size());
 
         Iterator<FileAnnotation> iterator = warnings.iterator();
         FileAnnotation annotation = iterator.next();
@@ -62,6 +62,18 @@ public class SunCParserTest extends ParserTester {
                 MESSAGE,
                 "ServerList.cpp",
                 TYPE, CATEGORY, Priority.NORMAL);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                19,
+                "Child::operator== hides the function Parent::operator==(Parent&) const.",
+                "warner.cpp",
+                TYPE, "hidef", Priority.NORMAL);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                30,
+                "Assigning void(*)(int) to extern \"C\" void(*)(int).",
+                "warner.cpp",
+                TYPE, "wbadlkgasg", Priority.NORMAL);
     }
 
     @Override

--- a/src/test/resources/hudson/plugins/warnings/parser/sunc.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/sunc.txt
@@ -5,3 +5,5 @@
 "ServerList.cpp", line 44: Warning, badargtypel2w: String literal converted to char* in formal argument 1 in call to userlog(char*, ...).
 "ServerList.cpp", line 50: Warning, badargtypel2w: String literal converted to char* in formal argument 1 in call to userlog(char*, ...).
 
+"warner.cpp", line 19: Warning, hidef: Child::operator== hides the function Parent::operator==(Parent&) const.
+"warner.cpp", line 30: Warning (Anachronism), wbadlkgasg: Assigning void(*)(int) to extern "C" void(*)(int).


### PR DESCRIPTION
I actually e-mailed you about this long ago (25.04.2013) but hadn't got around to setting up an environment for modifying and testing Jenkins plugin stuff.

If the warning description included a colon, it was greedily matching
up to that colon for the category. Also, some warnings are tagged with
"(Anachronism)" and so weren't matched.

For the categories to work, people should compile with -errtags=yes. Is it possible to offer that as advice somehow/somewhere in the web interface when people select the Sun C++ parser?