### PR TITLE
Test cases for warning categories from gcc and sun C++ compilers

### DIFF
--- a/src/test/java/hudson/plugins/warnings/parser/Gcc4CompilerParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/Gcc4CompilerParserTest.java
@@ -80,7 +80,7 @@ public class Gcc4CompilerParserTest extends ParserTester {
     public void testWarningsParser() throws IOException {
         Collection<FileAnnotation> warnings = new Gcc4CompilerParser().parse(openFile());
 
-        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 13, warnings.size());
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 14, warnings.size());
 
         Iterator<FileAnnotation> iterator = warnings.iterator();
         checkWarning(iterator.next(),
@@ -148,6 +148,11 @@ public class Gcc4CompilerParserTest extends ParserTester {
                 "expected ';' before 'return'",
                 "fo:oo.cpp",
                 WARNING_TYPE, ERROR_CATEGORY, Priority.HIGH);
+	checkWarning(iterator.next(),
+                23,
+		"unused variable 'j' [-Wunused-variable]",
+		"warner.cpp",
+		WARNING_TYPE, "Warning:unused-variable", Priority.NORMAL);
     }
 
     /**

--- a/src/test/java/hudson/plugins/warnings/parser/SunCParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/SunCParserTest.java
@@ -20,7 +20,7 @@ public class SunCParserTest extends ParserTester {
     private static final String CATEGORY = "badargtypel2w";
 
     /**
-     * Parses a file with 7 warnings.
+     * Parses a file with 8 warnings.
      *
      * @throws IOException
      *      if the file could not be read
@@ -29,7 +29,7 @@ public class SunCParserTest extends ParserTester {
     public void parseSunCpp() throws IOException {
         Collection<FileAnnotation> warnings = new SunCParser().parse(openFile());
 
-        assertEquals("Wrong number of warnings detected.", 7, warnings.size());
+        assertEquals("Wrong number of warnings detected.", 8, warnings.size());
 
         Iterator<FileAnnotation> iterator = warnings.iterator();
         FileAnnotation annotation = iterator.next();
@@ -74,6 +74,13 @@ public class SunCParserTest extends ParserTester {
                 "Assigning void(*)(int) to extern \"C\" void(*)(int).",
                 "warner.cpp",
                 TYPE, "wbadlkgasg", Priority.NORMAL);
+        annotation = iterator.next();
+	// test warning where -errtags=yes was not used
+        checkWarning(annotation,
+                32,
+                "statement is unreachable.",
+                "warner.cpp",
+                TYPE, "", Priority.NORMAL);
     }
 
     @Override

--- a/src/test/resources/hudson/plugins/warnings/parser/gcc4.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/gcc4.txt
@@ -42,3 +42,7 @@ fo:oo.cpp: In function 'int main()':
 fo:oo.cpp:8: error: 'bar' was not declared in this scope
 fo:oo.cpp:12: error: expected ';' before 'return'
 foo bar.hello*world:12:
+
+=============== Check with a category - -fdiagnostics-show-option
+warner.cpp: In function 'void dispatcher(int)':
+warner.cpp:23: warning: unused variable 'j' [-Wunused-variable]

--- a/src/test/resources/hudson/plugins/warnings/parser/sunc.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/sunc.txt
@@ -7,3 +7,4 @@
 
 "warner.cpp", line 19: Warning, hidef: Child::operator== hides the function Parent::operator==(Parent&) const.
 "warner.cpp", line 30: Warning (Anachronism), wbadlkgasg: Assigning void(*)(int) to extern "C" void(*)(int).
+"warner.cpp", line 32: Warning: statement is unreachable.


### PR DESCRIPTION
All this adds is a couple of test cases. This follows on from the previous (#68) pull request where you asked what happens if a user doesn't use -errtags=yes. So this adds a test case for a warning that might result. For gcc, there didn't appear to be any test cases for the converse situation where -fdiagnostics-show-option is used so this adds one. Note that with gcc, this is actually now the default and -fno-diagnostics-show-option is needed to disable it.

Behaviour is not entirely consistent between the gcc and Sun C++ parsers. For the gnu compiler, the categories are all prefixed with either "Warning:" or "Error:". This seems superfluous to me given that we have the priority. Gcc is also including the option description in the warning description.