### PR TITLE
Do not persist GroovyParser.example

### DIFF
--- a/src/main/java/hudson/plugins/warnings/GroovyParser.java
+++ b/src/main/java/hudson/plugins/warnings/GroovyParser.java
@@ -326,7 +326,7 @@ public class GroovyParser extends AbstractDescribableImpl<GroovyParser> {
                 if (example.length() <= MAX_EXAMPLE_SIZE) {
                     return response;
                 }
-                return FormValidation.aggregate(Arrays.asList(FormValidation.warning("Long examples will be truncated"), response));
+                return FormValidation.aggregate(Arrays.asList(FormValidation.warning(Messages.GroovyParser_long_examples_will_be_truncated()), response));
             }
             else {
                 return FormValidation.ok();

--- a/src/main/java/hudson/plugins/warnings/GroovyParser.java
+++ b/src/main/java/hudson/plugins/warnings/GroovyParser.java
@@ -30,8 +30,6 @@ public class GroovyParser extends AbstractDescribableImpl<GroovyParser> {
     private final String name;
     private final String regexp;
     private final String script;
-    /** Example. @since 3.18 */
-    private final String example;
     /** ProjectAction name. @since 4.0 */
     private String linkName;
     /** Trend report name. @since 4.0 */
@@ -56,17 +54,22 @@ public class GroovyParser extends AbstractDescribableImpl<GroovyParser> {
      *            the name of the trend report
      */
     @DataBoundConstructor
-    public GroovyParser(final String name, final String regexp, final String script, final String example,
+    public GroovyParser(final String name, final String regexp, final String script,
             final String linkName, final String trendName) {
         super();
 
         this.name = name;
         this.regexp = regexp;
         this.script = script;
-        this.example = example;
         this.linkName = linkName;
         this.trendName = trendName;
         parser = createParser();
+    }
+
+    @Deprecated
+    public GroovyParser(final String name, final String regexp, final String script, final String example,
+            final String linkName, final String trendName) {
+        this(name, regexp, script, linkName, trendName);
     }
 
     /**
@@ -80,7 +83,7 @@ public class GroovyParser extends AbstractDescribableImpl<GroovyParser> {
      *            the script to map the expression to a warning
      */
     public GroovyParser(final String name, final String regexp, final String script) {
-        this(name, regexp, script, StringUtils.EMPTY, name, name);
+        this(name, regexp, script, name, name);
     }
 
     /**
@@ -159,16 +162,6 @@ public class GroovyParser extends AbstractDescribableImpl<GroovyParser> {
      */
     public String getScript() {
         return script;
-    }
-
-    /**
-     * Returns the example to verify the parser.
-     *
-     * @return the example
-     * @since 3.18
-     */
-    public String getExample() {
-        return StringUtils.defaultString(example);
     }
 
     /**

--- a/src/main/resources/hudson/plugins/warnings/Messages.properties
+++ b/src/main/resources/hudson/plugins/warnings/Messages.properties
@@ -1,3 +1,4 @@
+GroovyParser.long_examples_will_be_truncated=Long examples will be truncated
 Warnings.Warnings.ColumnHeader=# Compiler Warnings
 Warnings.Warnings.Column=Number of compiler warnings
 


### PR DESCRIPTION
I was called in today to investigate a Jenkins instance whose system configuration page could not be saved—it would yield the dreaded `This page expects a form submission but had only {}` error. After seeing that the POSTed form body was over 2Mb, I tracked down the problem to the `GroovyParser.example` field for one parser. Someone had pasted in a large log file at some point, and its complete text was being round-tripped thereafter; either the size or some mojibake was evidently causing problems during submission.

At any rate, there is no clear reason to ever save this field—it is only used for its form validation when you are editing other fields. That form validation continues to work when it is not persisted.

@reviewbybees esp. @jtnord