### PR TITLE
GnuMakeGccParser: Slightly adjust make pattern for current version

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/GnuMakeGccParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/GnuMakeGccParser.java
@@ -25,7 +25,7 @@ public class GnuMakeGccParser extends RegexpLineParser {
             + "(?:.*\\[.*\\])?\\s*" // ANT_TASK
             + "(.*\\.[chpimxsola0-9]+):(\\d+):(?:\\d+:)? (warning|error): (.*)$" // GCC 4 warning
             + ")|("
-            + "(^g?make\\[.*\\]: Entering directory)\\s*(\\`((.*))\\')" // handle make entering directory
+            + "(^g?make\\[.*\\]: Entering directory)\\s*(['`]((.*))\\')" // handle make entering directory
             + ")";
     private String directory = "";
 

--- a/src/test/resources/hudson/plugins/warnings/parser/gnuMakeGcc.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/gnuMakeGcc.txt
@@ -34,7 +34,7 @@ warnings.cc:14:   instantiated from here
 warnings.cc:6: warning: passing 'Test' chooses 'int' over 'unsigned int'
 warnings.cc:6: warning:   in call to 'std::basic_ostream<_CharT, _Traits>& std::basic_ostream<_CharT, _Traits>::operator<<(int) [with _CharT = char, _Traits = std::char_traits<char>]'
 
-make[2]: Entering directory `/dir1/dir2/dir3'
+make[2]: Entering directory '/dir1/dir2/dir3'
 =============== Issue 5605
 In file included from /usr/include/c++/4.3/backward/hash_set:64,
                  from /usr/include/boost/graph/adjacency_list.hpp:25,
@@ -46,6 +46,6 @@ fo:oo.cpp: In function 'int main()':
 fo:oo.cpp:8: error: 'bar' was not declared in this scope
 fo:oo.cpp:12: error: expected ';' before 'return'
 foo bar.hello*world:12:
-make[2]: Leaving directory `/dir1/dir2/dir3'
+make[2]: Leaving directory '/dir1/dir2/dir3'
 make[1]: Leaving directory `/dir1/dir2'
 make[0]: Leaving directory `/dir1'


### PR DESCRIPTION
Atleast GNU Make 4.0 produces messages of the form
make[1]: Entering directory '/some/dir'
This commit corrects the pattern to catch these messages.

Some bigger feature request would be to separate the tracking of dir changes
and be able to combine it with other matchers like Clang.