### PR TITLE
Ignore MSBuild timestamp when extracting filename

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/MsBuildParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/MsBuildParser.java
@@ -20,8 +20,8 @@ import hudson.plugins.analysis.util.model.Priority;
 public class MsBuildParser extends RegexpLineParser {
     private static final long serialVersionUID = -2141974437420906595L;
     static final String WARNING_TYPE = "MSBuild";
-    private static final String MS_BUILD_WARNING_PATTERN = ANT_TASK + "(?:\\s*\\d+>)?(?:(?:(?:(.*)\\((\\d*)(?:,(\\d+))?.*\\)|.*LINK)\\s*:|(.*):)\\s*([A-z-_]*\\s?(?:[Nn]ote|[Ii]nfo|[Ww]arning|(?:fatal\\s*)?[Ee]rror))\\s*:?\\s*([A-Za-z0-9]+)\\s*:\\s(?:\\s*([A-Za-z0-9.]+)\\s*:)?\\s*(.*?)(?: \\[([^\\]]*)[/\\\\][^\\]\\\\]+\\])?"
-            + "|(.*)\\s*:.*error\\s*(LNK[0-9]+):\\s*(.*))$";
+    private static final String MS_BUILD_WARNING_PATTERN = ANT_TASK + 
+        "(?:\\s*\\d{2}:\\d{2}:\\d{2}\\.\\d{3})?(?:\\s*\\d+>)?(?:(?:(?:(.*)\\((\\d*)(?:,(\\d+))?.*\\)|.*LINK)\\s*:|(.*):)\\s*([A-z-_]*\\s?(?:[Nn]ote|[Ii]nfo|[Ww]arning|(?:fatal\\s*)?[Ee]rror))\\s*:?\\s*([A-Za-z0-9]+)\\s*:\\s(?:\\s*([A-Za-z0-9.]+)\\s*:)?\\s*(.*?)(?: \\[([^\\]]*)[/\\\\][^\\]\\\\]+\\])?|(.*)\\s*:.*error\\s*(LNK[0-9]+):\\s*(.*))$";
 
     /**
      * Creates a new instance of {@link MsBuildParser}.


### PR DESCRIPTION
MSBuild can add a hh:mm:ss.fff timestamp to the front of build output if you want it to. This change ignores the timestamp so the filename extraction continues to work.
