### PR TITLE
added help tip for ansible lint

### DIFF
--- a/src/main/webapp/help.html
+++ b/src/main/webapp/help.html
@@ -67,6 +67,16 @@ ORDER BY object_type, object_name;
   <pre>
       <code>find . -iname *.pp -exec puppet-lint --log-format "%{path}:%{line}:%{check}:%{KIND}:%{message}" {} \;</code>
   </pre>
+
+  <h4>Ansible Lint</h4>
+  <p>
+    To be able to grab ansible lint output, you will need to add
+    the <code>-p flag</code>.<br/>
+  </p>
+  <p>Example:</p>
+  <pre>
+      <code>ansible-lint -p example_file.yml</code>
+  </pre>
   
   <h4>JSLint</h4>
   <p>


### PR DESCRIPTION
Hi Ulli,

I think I need to add this tip as ansible-lint output has 2 formats: default (output in multi-line) and pep8 (1 line output), but the parser can parse only pep8 format currently. 

Anything you want to change or you've got a better idea, please let me know.

Thank you.

![ansible-lint-dff-output-formats](https://cloud.githubusercontent.com/assets/16824530/19629910/e0ed6a4c-9976-11e6-9632-696e6cb188ae.png)
