### PR TITLE
Expose methods to allow adding parsers through scripting

### DIFF
--- a/src/main/java/hudson/plugins/warnings/WarningsDescriptor.java
+++ b/src/main/java/hudson/plugins/warnings/WarningsDescriptor.java
@@ -153,23 +153,32 @@ public final class WarningsDescriptor extends PluginDescriptor implements Staple
     }
 
     /**
-     * Replaces the list of given groovy Parsers
-     *
-     * @return the Boolean value after replacing the given groovy Parsers.
+     * Adds the given Groovy parser to the configured Groovy parsers
      */
-
-    public boolean replaceGroovyParsers(List<GroovyParser> groovyParserList) {
-        groovyParsers.replaceBy(groovyParserList);
-
+    public void addGroovyParser(GroovyParser parser) {
+        groovyParsers.add(parser);
         save();
+    }
 
-        return true;
+    /**
+     * Adds the given list of Groovy parsers to the configured Groovy parsers
+     */
+    public void addGroovyParsers(List<GroovyParser> parsers) {
+        groovyParsers.addAll(parsers);
+        save();
+    }
+
+    /**
+     * Replaces the configured Groovy parsers with the given list.
+     */
+    public void replaceGroovyParsers(List<GroovyParser> parsers) {
+        groovyParsers.replaceBy(parsers);
+        save();
     }
 
     @Override
     public boolean configure(final StaplerRequest req, final JSONObject formData) {
         replaceGroovyParsers(req.bindJSONToList(GroovyParser.class, formData.get("parsers")));
-
         return true;
     }
 

--- a/src/main/java/hudson/plugins/warnings/WarningsDescriptor.java
+++ b/src/main/java/hudson/plugins/warnings/WarningsDescriptor.java
@@ -1,6 +1,7 @@
 package hudson.plugins.warnings;
 
 import java.io.IOException;
+import java.util.Collection;
 
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.AncestorInPath;
@@ -20,7 +21,6 @@ import hudson.plugins.analysis.graph.GraphConfiguration;
 import hudson.plugins.warnings.parser.ParserRegistry;
 import hudson.util.CopyOnWriteList;
 import hudson.util.FormValidation;
-import java.util.List;
 
 /**
  * Descriptor for the class {@link WarningsPublisher}. Used as a singleton. The
@@ -155,23 +155,23 @@ public final class WarningsDescriptor extends PluginDescriptor implements Staple
     /**
      * Adds the given Groovy parser to the configured Groovy parsers
      */
-    public void addGroovyParser(GroovyParser parser) {
+    public void addGroovyParser(final GroovyParser parser) {
         groovyParsers.add(parser);
         save();
     }
 
     /**
-     * Adds the given list of Groovy parsers to the configured Groovy parsers
+     * Adds the given collection of Groovy parsers to the configured Groovy parsers
      */
-    public void addGroovyParsers(List<GroovyParser> parsers) {
+    public void addGroovyParsers(final Collection<GroovyParser> parsers) {
         groovyParsers.addAll(parsers);
         save();
     }
 
     /**
-     * Replaces the configured Groovy parsers with the given list.
+     * Replaces the configured Groovy parsers with the given collection.
      */
-    public void replaceGroovyParsers(List<GroovyParser> parsers) {
+    public void replaceGroovyParsers(final Collection<GroovyParser> parsers) {
         groovyParsers.replaceBy(parsers);
         save();
     }
@@ -181,7 +181,6 @@ public final class WarningsDescriptor extends PluginDescriptor implements Staple
         replaceGroovyParsers(req.bindJSONToList(GroovyParser.class, formData.get("parsers")));
         return true;
     }
-
 
     @Override
     public FormValidation doCheckPattern(@AncestorInPath final AbstractProject<?, ?> project,

--- a/src/main/java/hudson/plugins/warnings/WarningsDescriptor.java
+++ b/src/main/java/hudson/plugins/warnings/WarningsDescriptor.java
@@ -20,6 +20,7 @@ import hudson.plugins.analysis.graph.GraphConfiguration;
 import hudson.plugins.warnings.parser.ParserRegistry;
 import hudson.util.CopyOnWriteList;
 import hudson.util.FormValidation;
+import java.util.List;
 
 /**
  * Descriptor for the class {@link WarningsPublisher}. Used as a singleton. The
@@ -151,14 +152,27 @@ public final class WarningsDescriptor extends PluginDescriptor implements Staple
         return groovyParsers.toArray(new GroovyParser[groovyParsers.size()]);
     }
 
-    @Override
-    public boolean configure(final StaplerRequest req, final JSONObject formData) {
-        groovyParsers.replaceBy(req.bindJSONToList(GroovyParser.class, formData.get("parsers")));
+    /**
+     * Replaces the list of given groovy Parsers
+     *
+     * @return the Boolean value after replacing the given groovy Parsers.
+     */
+
+    public boolean replaceGroovyParsers(List<GroovyParser> groovyParserList) {
+        groovyParsers.replaceBy(groovyParserList);
 
         save();
 
         return true;
     }
+
+    @Override
+    public boolean configure(final StaplerRequest req, final JSONObject formData) {
+        replaceGroovyParsers(req.bindJSONToList(GroovyParser.class, formData.get("parsers")));
+
+        return true;
+    }
+
 
     @Override
     public FormValidation doCheckPattern(@AncestorInPath final AbstractProject<?, ?> project,


### PR DESCRIPTION
Related to and building on #82.

It'd be great if we could manipulate the configured parsers through the script console or through Jenkins' start-up scripts. I took the existing commit from #82 and added two methods to add a single or multiple parsers.

Pinging @ewelinawilkosz2 as it relates to her current project.