### PR TITLE
parsers: Implement basic Cadence Insicive Enterprise Simulator parser

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/CadenceIncisiveParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/CadenceIncisiveParser.java
@@ -7,6 +7,8 @@ package hudson.plugins.warnings.parser;
 import java.util.regex.Matcher;
 import hudson.Extension;
 import hudson.plugins.analysis.util.model.Priority;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  *
@@ -18,11 +20,13 @@ import hudson.plugins.analysis.util.model.Priority;
 public class CadenceIncisiveParser extends RegexpLineParser {
     private static final String SLASH = "/";
     private static final String CADENCE_MESSAGE_PATTERN = "("
-            + "(^[a-zA-Z]+): \\*([a-zA-Z]),([a-zA-Z]+): (.*)$" //Single warning
-            + ")|("
+            + "(^[a-zA-Z]+): \\*([a-zA-Z]),([a-zA-Z]+): (.*) \\[File:(.*), Line:(.*)\\]." //ncelab vhdl warning
+             + ")|("
             + "(^[a-zA-Z]+): \\*([a-zA-Z]),([a-zA-Z]+) \\((.*),([0-9]+)\\|([0-9]+)\\): (.*)$" //Warning/error with filename
             + ")|("
             + "(^g?make\\[.*\\]: Entering directory)\\s*(['`]((.*))\\')" // make: entering directory
+            + ")|("
+            + "(^[a-zA-Z]+): \\*([a-zA-Z]),([a-zA-Z]+): (.*)$" //Single generic warning
             + ")";
     private String directory = "";
     
@@ -41,35 +45,60 @@ public class CadenceIncisiveParser extends RegexpLineParser {
         return "Cadence Incisive Enterprise Simulator";
     }
 
+    
+    private Warning handleDirectory(final Matcher matcher, int offset) {
+        directory = matcher.group(offset) + SLASH; //17
+        return FALSE_POSITIVE;
+    }
+
+    
     @Override
     protected Warning createWarning(final Matcher matcher) {
 
         String tool, type, category, message, fileName; 
         int lineNumber = 0;
         int column = 0;
+
+
+        List<String> arr = new ArrayList<String>();
+        int n = matcher.groupCount();
+        for (int i = 0; i<= n; i++)
+            arr.add(i,matcher.group(i));
+        
         Priority priority = Priority.LOW;
         
-        if (matcher.group(14) != null)
-        {
-            /* Set current directory */
-            return handleDirectory(matcher);            
-        } else if (matcher.group(6) != null) {
-            tool = matcher.group(7);
-            type = matcher.group(8);
-            category = matcher.group(9);
-            fileName = matcher.group(10);
-            lineNumber = getLineNumber(matcher.group(11));
-            /* column = matcher.group(12); */
-            message = matcher.group(13);
-        } else {
+        if (matcher.group(1) != null)
+        { 
+            /* vhdl warning from ncelab */
             tool = matcher.group(2);
             type = matcher.group(3);
             category = matcher.group(4);
+            fileName = matcher.group(6);
+            lineNumber = getLineNumber(matcher.group(7));
             message = matcher.group(5);            
+        } else if (matcher.group(16) != null)
+        {
+            /* Set current directory */
+            return handleDirectory(matcher, 20);            
+        } else if (matcher.group(8) != null) {
+            tool = matcher.group(9);
+            type = matcher.group(10);
+            category = matcher.group(11);
+            fileName = matcher.group(12);
+            lineNumber = getLineNumber(matcher.group(13));
+            priority = Priority.NORMAL;
+            /* column = matcher.group(14); */
+            message = matcher.group(15);
+        } else if (matcher.group(21) != null) {
+            tool = matcher.group(22);
+            type = matcher.group(23);
+            category = matcher.group(24);
+            message = matcher.group(25);            
             fileName = "/NotFileRelated";
+        } else {
+            return FALSE_POSITIVE; /* Some shit happened ! */
         }
-         
-
+                 
         if (category.equalsIgnoreCase("E")) {
             priority = Priority.HIGH;
             category = "Error (" + tool + "): " + category;
@@ -85,8 +114,5 @@ public class CadenceIncisiveParser extends RegexpLineParser {
         }
     }
     
-private Warning handleDirectory(final Matcher matcher) {
-        directory = matcher.group(17) + SLASH;
-        return FALSE_POSITIVE;
-    }
+
 }

--- a/src/main/java/hudson/plugins/warnings/parser/CadenceIncisiveParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/CadenceIncisiveParser.java
@@ -1,0 +1,92 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package hudson.plugins.warnings.parser;
+import java.util.regex.Matcher;
+import hudson.Extension;
+import hudson.plugins.analysis.util.model.Priority;
+
+/**
+ *
+ * A parser for Cadence Incisive Enterprise Simulator
+ * @author Andrew 'Necromant' Andrianov
+ */
+
+@Extension
+public class CadenceIncisiveParser extends RegexpLineParser {
+    private static final String SLASH = "/";
+    private static final String CADENCE_MESSAGE_PATTERN = "("
+            + "(^[a-zA-Z]+): \\*([a-zA-Z]),([a-zA-Z]+): (.*)$" //Single warning
+            + ")|("
+            + "(^[a-zA-Z]+): \\*([a-zA-Z]),([a-zA-Z]+) \\((.*),([0-9]+)\\|([0-9]+)\\): (.*)$" //Warning/error with filename
+            + ")|("
+            + "(^g?make\\[.*\\]: Entering directory)\\s*(['`]((.*))\\')" // make: entering directory
+            + ")";
+    private String directory = "";
+    
+    /**
+     * Creates a new instance of {@link CadenceIncisiveParser}.
+     */
+    public CadenceIncisiveParser() {
+        super(Messages._Warnings_CadenceIncisive_ParserName(),
+                Messages._Warnings_CadenceIncisive_LinkName(),
+                Messages._Warnings_CadenceIncisive_TrendName(),
+                CADENCE_MESSAGE_PATTERN);
+    }
+
+    @Override
+    protected String getId() {
+        return "Cadence Incisive Enterprise Simulator";
+    }
+
+    @Override
+    protected Warning createWarning(final Matcher matcher) {
+
+        String tool, type, category, message, fileName; 
+        int lineNumber = 0;
+        int column = 0;
+        Priority priority = Priority.LOW;
+        
+        if (matcher.group(14) != null)
+        {
+            /* Set current directory */
+            return handleDirectory(matcher);            
+        } else if (matcher.group(6) != null) {
+            tool = matcher.group(7);
+            type = matcher.group(8);
+            category = matcher.group(9);
+            fileName = matcher.group(10);
+            lineNumber = getLineNumber(matcher.group(11));
+            /* column = matcher.group(12); */
+            message = matcher.group(13);
+        } else {
+            tool = matcher.group(2);
+            type = matcher.group(3);
+            category = matcher.group(4);
+            message = matcher.group(5);            
+            fileName = "/NotFileRelated";
+        }
+         
+
+        if (category.equalsIgnoreCase("E")) {
+            priority = Priority.HIGH;
+            category = "Error (" + tool + "): " + category;
+        } else {
+            priority = Priority.LOW;
+            category = "Warning (" + tool + "): " + category;
+        }
+
+        if (fileName.startsWith(SLASH)) {
+            return createWarning(fileName, lineNumber, category, message, priority);
+        } else {
+            return createWarning(directory + fileName, lineNumber, category, message, priority);
+        }
+    }
+    
+private Warning handleDirectory(final Matcher matcher) {
+        directory = matcher.group(17) + SLASH;
+        return FALSE_POSITIVE;
+    }
+}

--- a/src/main/java/hudson/plugins/warnings/parser/CadenceIncisiveParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/CadenceIncisiveParser.java
@@ -76,6 +76,7 @@ public class CadenceIncisiveParser extends RegexpLineParser {
             fileName = matcher.group(6);
             lineNumber = getLineNumber(matcher.group(7));
             message = matcher.group(5);            
+            priority = Priority.NORMAL;
         } else if (matcher.group(16) != null)
         {
             /* Set current directory */
@@ -103,7 +104,6 @@ public class CadenceIncisiveParser extends RegexpLineParser {
             priority = Priority.HIGH;
             category = "Error (" + tool + "): " + category;
         } else {
-            priority = Priority.LOW;
             category = "Warning (" + tool + "): " + category;
         }
 

--- a/src/main/resources/hudson/plugins/warnings/parser/Messages.properties
+++ b/src/main/resources/hudson/plugins/warnings/parser/Messages.properties
@@ -1,3 +1,4 @@
+CadenceIncisiveParser._a_za_z_w_a_za_z_=(^[a-zA-Z]+): *W,([a-zA-Z]+): (.*)
 Warnings.NotLocalizedName={0}
 
 Warnings.Maven.ParserName=Maven
@@ -175,6 +176,10 @@ Warnings.AppleLLVMClang.TrendName=LLVM/Clang Warnings Trend
 Warnings.GnuMakeGcc.ParserName=GNU Make + GNU C Compiler (gcc)
 Warnings.GnuMakeGcc.LinkName=GNU Make + GNU C Compiler Warnings
 Warnings.GnuMakeGcc.TrendName=GNU Make + GNU C Compiler Trend
+
+Warnings.CadenceIncisive.ParserName=Cadence Incisive (with GNU Make)
+Warnings.CadenceIncisive.LinkName=Cadence Incisive Warnings
+Warnings.CadenceIncisive.TrendName=Cadence Incisive Warnings Trend
 
 Warnings.Xlc.ParserName=IBM XLC Compiler
 Warnings.Xlc.LinkName=IBM XLC Compiler Warnings

--- a/src/test/java/hudson/plugins/warnings/parser/CadenceIncisiveParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/CadenceIncisiveParserTest.java
@@ -12,7 +12,7 @@ import hudson.plugins.analysis.util.model.FileAnnotation;
 import hudson.plugins.analysis.util.model.Priority;
 
 /**
- * Tests the class {@link CadenceIncisiveParserTest}.
+ * Tests the class {@link CadenceIncisiveParser}.
  *
  * @author Andrew 'Necromant' Andrianov
  */
@@ -20,7 +20,7 @@ public class CadenceIncisiveParserTest extends ParserTester {
     private static final String WARNING_TYPE = new CadenceIncisiveParser().getGroup();
 
     /**
-     * Test of createWarning method, of class {@link GnuMakeGccParser}.
+     * Test of createWarning method, of class {@link CadenceIncisiveParser}.
      *
      * @throws IOException
      *             in case of an error
@@ -34,19 +34,19 @@ public class CadenceIncisiveParserTest extends ParserTester {
         Iterator<FileAnnotation> iterator = warnings.iterator();
         checkWarning(iterator.next(),
                 0,
-                "Resolved design unit 'shittyram' at 'u_shittyrams' to 'shittysoc.shittyram:v' through a global search of all libraries.",
+                "Resolved design unit 'dummyram' at 'u_dummyrams' to 'dummysoc.dummyram:v' through a global search of all libraries.",
                 "/NotFileRelated",
                 WARNING_TYPE, "Warning (ncelab): CUSRCH", Priority.LOW);
 
         checkWarning(iterator.next(),
                 313,
                 "10 output ports were not connected",
-                "/tmp/build-dir/../verilog/shit.v",
+                "/tmp/build-dir/../verilog/placeholder.v",
                 WARNING_TYPE, "Warning (ncelab): CUVWSP", Priority.NORMAL);
 
         checkWarning(iterator.next(),
                 310,
-                "component instance is not fully bound (some.long:shit:blah:r1)",
+                "component instance is not fully bound (some.long:placeholder:blah:r1)",
                 "/tmp/build-dir/freaking_gbit_astral.vhd",
                 WARNING_TYPE, "Warning (ncelab): CUNOTB", Priority.NORMAL);
 

--- a/src/test/java/hudson/plugins/warnings/parser/CadenceIncisiveParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/CadenceIncisiveParserTest.java
@@ -42,13 +42,13 @@ public class CadenceIncisiveParserTest extends ParserTester {
                 313,
                 "10 output ports were not connected",
                 "/tmp/build-dir/../verilog/shit.v",
-                WARNING_TYPE, "Warning (ncelab): CUVWSP", Priority.LOW);
+                WARNING_TYPE, "Warning (ncelab): CUVWSP", Priority.NORMAL);
 
         checkWarning(iterator.next(),
                 310,
                 "component instance is not fully bound (some.long:shit:blah:r1)",
                 "/tmp/build-dir/freaking_gbit_astral.vhd",
-                WARNING_TYPE, "Warning (ncelab): CUNOTB", Priority.LOW);
+                WARNING_TYPE, "Warning (ncelab): CUNOTB", Priority.NORMAL);
 
     }
 

--- a/src/test/java/hudson/plugins/warnings/parser/CadenceIncisiveParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/CadenceIncisiveParserTest.java
@@ -1,0 +1,53 @@
+package hudson.plugins.warnings.parser;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.junit.Test;
+
+import hudson.plugins.analysis.util.model.FileAnnotation;
+import hudson.plugins.analysis.util.model.Priority;
+
+/**
+ * Tests the class {@link CadenceIncisiveParserTest}.
+ *
+ * @author Andrew 'Necromant' Andrianov
+ */
+public class CadenceIncisiveParserTest extends ParserTester {
+    private static final String WARNING_TYPE = new CadenceIncisiveParser().getGroup();
+
+    /**
+     * Test of createWarning method, of class {@link GnuMakeGccParser}.
+     *
+     * @throws IOException
+     *             in case of an error
+     */
+    @Test
+    public void testCreateWarning() throws IOException {
+        Collection<FileAnnotation> warnings = new CadenceIncisiveParser().parse(openFile());
+
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 2, warnings.size());
+
+        Iterator<FileAnnotation> iterator = warnings.iterator();
+        checkWarning(iterator.next(),
+                0,
+                "Resolved design unit 'shittyram' at 'u_shittyrams' to 'shittysoc.shittyram:v' through a global search of all libraries.",
+                "/NotFileRelated",
+                WARNING_TYPE, "Warning (ncelab): CUSRCH", Priority.LOW);
+
+        checkWarning(iterator.next(),
+                313,
+                "10 output ports were not connected",
+                "/tmp/build-dir/../verilog/shit.v",
+                WARNING_TYPE, "Warning (ncelab): CUVWSP", Priority.LOW);
+
+    }
+
+    @Override
+    protected String getWarningsFile() {
+        return "CadenceIncisive.txt";
+    }
+}

--- a/src/test/java/hudson/plugins/warnings/parser/CadenceIncisiveParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/CadenceIncisiveParserTest.java
@@ -29,7 +29,7 @@ public class CadenceIncisiveParserTest extends ParserTester {
     public void testCreateWarning() throws IOException {
         Collection<FileAnnotation> warnings = new CadenceIncisiveParser().parse(openFile());
 
-        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 2, warnings.size());
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 3, warnings.size());
 
         Iterator<FileAnnotation> iterator = warnings.iterator();
         checkWarning(iterator.next(),
@@ -43,6 +43,12 @@ public class CadenceIncisiveParserTest extends ParserTester {
                 "10 output ports were not connected",
                 "/tmp/build-dir/../verilog/shit.v",
                 WARNING_TYPE, "Warning (ncelab): CUVWSP", Priority.LOW);
+
+        checkWarning(iterator.next(),
+                310,
+                "component instance is not fully bound (some.long:shit:blah:r1)",
+                "/tmp/build-dir/freaking_gbit_astral.vhd",
+                WARNING_TYPE, "Warning (ncelab): CUNOTB", Priority.LOW);
 
     }
 

--- a/src/test/java/hudson/plugins/warnings/parser/ParserRegistryIntegrationTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/ParserRegistryIntegrationTest.java
@@ -38,7 +38,7 @@ import hudson.plugins.warnings.GroovyParserTest;
  */
 public class ParserRegistryIntegrationTest {
     /** If you add a new parser then this value needs to be adapted. */
-    private static final int NUMBER_OF_AVAILABLE_PARSERS = 66;
+    private static final int NUMBER_OF_AVAILABLE_PARSERS = 67;
     private static final String OLD_ID_ECLIPSE_JAVA_COMPILER = "Eclipse Java Compiler";
     private static final String JAVA_WARNINGS_FILE = "deprecations.txt";
     private static final String OLD_ID_JAVA_COMPILER = "Java Compiler";

--- a/src/test/resources/hudson/plugins/warnings/parser/CadenceIncisive.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/CadenceIncisive.txt
@@ -1,3 +1,4 @@
 make[2]: Entering directory '/tmp/build-dir'
 ncelab: *W,CUSRCH: Resolved design unit 'shittyram' at 'u_shittyrams' to 'shittysoc.shittyram:v' through a global search of all libraries.
 ncelab: *W,CUVWSP (../verilog/shit.v,313|24): 10 output ports were not connected
+ncelab: *W,CUNOTB: component instance is not fully bound (some.long:shit:blah:r1) [File:freaking_gbit_astral.vhd, Line:310].

--- a/src/test/resources/hudson/plugins/warnings/parser/CadenceIncisive.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/CadenceIncisive.txt
@@ -1,0 +1,3 @@
+make[2]: Entering directory '/tmp/build-dir'
+ncelab: *W,CUSRCH: Resolved design unit 'shittyram' at 'u_shittyrams' to 'shittysoc.shittyram:v' through a global search of all libraries.
+ncelab: *W,CUVWSP (../verilog/shit.v,313|24): 10 output ports were not connected

--- a/src/test/resources/hudson/plugins/warnings/parser/CadenceIncisive.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/CadenceIncisive.txt
@@ -1,4 +1,4 @@
 make[2]: Entering directory '/tmp/build-dir'
-ncelab: *W,CUSRCH: Resolved design unit 'shittyram' at 'u_shittyrams' to 'shittysoc.shittyram:v' through a global search of all libraries.
-ncelab: *W,CUVWSP (../verilog/shit.v,313|24): 10 output ports were not connected
-ncelab: *W,CUNOTB: component instance is not fully bound (some.long:shit:blah:r1) [File:freaking_gbit_astral.vhd, Line:310].
+ncelab: *W,CUSRCH: Resolved design unit 'dummyram' at 'u_dummyrams' to 'dummysoc.dummyram:v' through a global search of all libraries.
+ncelab: *W,CUVWSP (../verilog/placeholder.v,313|24): 10 output ports were not connected
+ncelab: *W,CUNOTB: component instance is not fully bound (some.long:placeholder:blah:r1) [File:freaking_gbit_astral.vhd, Line:310].


### PR DESCRIPTION
This simple patch implements basic parsing of Cadence HDL Simulation tools. multi-line warnings/error aren't supported and it relies on GNU/Make to print "entering directory" when constructing file paths. 

The relevant test is also enclosed. 

Signed-off-by: Andrew Andrianov <andrew@ncrmnt.org>