### PR TITLE
Add support for Robot Framework Lint

### DIFF
--- a/src/main/java/hudson/plugins/warnings/WarningsDescriptor.java
+++ b/src/main/java/hudson/plugins/warnings/WarningsDescriptor.java
@@ -3,6 +3,7 @@ package hudson.plugins.warnings;
 import java.io.IOException;
 import java.util.Collection;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;

--- a/src/main/java/hudson/plugins/warnings/WarningsDescriptor.java
+++ b/src/main/java/hudson/plugins/warnings/WarningsDescriptor.java
@@ -3,7 +3,6 @@ package hudson.plugins.warnings;
 import java.io.IOException;
 import java.util.Collection;
 
-import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;

--- a/src/main/java/hudson/plugins/warnings/parser/RFLintParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/RFLintParser.java
@@ -4,14 +4,22 @@ import hudson.Extension;
 import hudson.plugins.analysis.util.model.Priority;
 
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
+ * A parser for <a href="http://robotframework.org/">Robot Framework</a>
+ * Parse output from <a href="https://github.com/boakley/robotframework-lint">robotframework-lint</a>
+ * To generate rflint file
+ * cmd$ pip install robotframework-lint
+ * cmd$ rflint path/to/test.robot
  * Created by traitanit on 3/27/2017 AD.
  */
 @Extension
 public class RFLintParser extends RegexpLineParser {
 
-    private static final String RFLINT_ERROR_PATTERN = "(.*): ([W|E|I]): (\\d+), (\\d+): (.*) \\((.*)\\)";
+    private static final String RFLINT_ERROR_PATTERN = "([W|E|I]): (\\d+), (\\d+): (.*) \\((.*)\\)";
+    private static final String RFLINT_FILE_PATTERN = "\\+\\s(.*)";
+    private String fileName;
 
     public RFLintParser(){
         super(Messages._Warnings_RFLint_ParserName(),
@@ -22,13 +30,20 @@ public class RFLintParser extends RegexpLineParser {
 
     @Override
     protected boolean isLineInteresting(String line) {
-        return line.contains("W") || line.contains("E") || line.contains("I");
+        Pattern filePattern = Pattern.compile(RFLINT_FILE_PATTERN);
+        Matcher matcher = filePattern.matcher(line);
+        if (matcher.find()) {
+            fileName = matcher.group(1);
+            return false;
+        }
+        return Pattern.matches(RFLINT_ERROR_PATTERN, line);
     }
+
 
     @Override
     protected Warning createWarning(Matcher matcher) {
-        String message = matcher.group(5);
-        String category = classifyIfEmpty(matcher.group(2), message);
+        String message = matcher.group(4);
+        String category = classifyIfEmpty(matcher.group(1), message);
         Priority priority = Priority.LOW;
         switch (category.charAt(0)){
             case 'E':
@@ -43,7 +58,9 @@ public class RFLintParser extends RegexpLineParser {
                 priority = Priority.LOW;
                 category = "IGNORE";
                 break;
+            default:
+                break;
         }
-        return createWarning(matcher.group(1), getLineNumber(matcher.group(3)), category, message, priority);
+        return createWarning(fileName, getLineNumber(matcher.group(2)), category, message, priority);
     }
 }

--- a/src/main/java/hudson/plugins/warnings/parser/RFLintParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/RFLintParser.java
@@ -1,0 +1,46 @@
+package hudson.plugins.warnings.parser;
+
+import hudson.Extension;
+import hudson.plugins.analysis.util.model.Priority;
+
+import java.util.regex.Matcher;
+
+/**
+ * Created by traitanit on 3/27/2017 AD.
+ */
+@Extension
+public class RFLintParser extends RegexpLineParser {
+
+    private static final String RFLINT_ERROR_PATTERN = "(.*):(\\d+) \\[([WEI])\\]: (.*) \\((\\d+)\\) \\((.*)\\)";
+
+    public RFLintParser(){
+        super(Messages._Warnings_RFLint_ParserName(),
+                Messages._Warnings_RFLint_LinkName(),
+                Messages._Warnings_RFLint_TrendName(),
+                RFLINT_ERROR_PATTERN, true);
+    }
+
+    @Override
+    protected boolean isLineInteresting(String line) {
+        return line.contains("[");
+    }
+
+    @Override
+    protected Warning createWarning(Matcher matcher) {
+        String message = matcher.group(4);
+        String category = classifyIfEmpty(matcher.group(3), message);
+        Priority priority = Priority.LOW;
+        switch (category.charAt(0)){
+            case 'E':
+                priority = Priority.HIGH;
+                break;
+            case 'W':
+                priority = Priority.NORMAL;
+                break;
+            case 'I':
+                priority = Priority.LOW;
+                break;
+        }
+        return createWarning(matcher.group(1), getLineNumber(matcher.group(2)), category, message, priority);
+    }
+}

--- a/src/main/java/hudson/plugins/warnings/parser/RFLintParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/RFLintParser.java
@@ -11,7 +11,7 @@ import java.util.regex.Matcher;
 @Extension
 public class RFLintParser extends RegexpLineParser {
 
-    private static final String RFLINT_ERROR_PATTERN = "(.*):(\\d+) \\[([WEI])\\]: (.*) \\((\\d+)\\) \\((.*)\\)";
+    private static final String RFLINT_ERROR_PATTERN = "(.*): ([W|E|I]): (\\d+), (\\d+): (.*) \\((.*)\\)";
 
     public RFLintParser(){
         super(Messages._Warnings_RFLint_ParserName(),
@@ -22,25 +22,28 @@ public class RFLintParser extends RegexpLineParser {
 
     @Override
     protected boolean isLineInteresting(String line) {
-        return line.contains("[");
+        return line.contains("W") || line.contains("E") || line.contains("I");
     }
 
     @Override
     protected Warning createWarning(Matcher matcher) {
-        String message = matcher.group(4);
-        String category = classifyIfEmpty(matcher.group(3), message);
+        String message = matcher.group(5);
+        String category = classifyIfEmpty(matcher.group(2), message);
         Priority priority = Priority.LOW;
         switch (category.charAt(0)){
             case 'E':
                 priority = Priority.HIGH;
+                category = "ERROR";
                 break;
             case 'W':
                 priority = Priority.NORMAL;
+                category = "WARNING";
                 break;
             case 'I':
                 priority = Priority.LOW;
+                category = "IGNORE";
                 break;
         }
-        return createWarning(matcher.group(1), getLineNumber(matcher.group(2)), category, message, priority);
+        return createWarning(matcher.group(1), getLineNumber(matcher.group(3)), category, message, priority);
     }
 }

--- a/src/main/resources/hudson/plugins/warnings/parser/Messages.properties
+++ b/src/main/resources/hudson/plugins/warnings/parser/Messages.properties
@@ -246,3 +246,7 @@ Warnings.SphinxBuild.TrendName=Sphinx-build Warnings Trend
 Warnings.AnsibleLint.ParserName=Ansible Lint
 Warnings.AnsibleLint.LinkName=Ansible Lint Warnings
 Warnings.AnsibleLint.TrendName=Ansible Lint Warnings Trend
+
+Warnings.RFLint.ParserName=Robot Framework Lint
+Warnings.RFLint.LinkName=Robot Framework Warnings
+Warnings.RFLint.TrendName=Robot Framework Warnings Trend

--- a/src/main/resources/hudson/plugins/warnings/parser/Messages_de.properties
+++ b/src/main/resources/hudson/plugins/warnings/parser/Messages_de.properties
@@ -223,3 +223,7 @@ Warnings.TaskingVXCompiler.TrendName=TASKING VX Compiler Warnungen Trend
 Warnings.SphinxBuild.ParserName=Sphinx-build
 Warnings.SphinxBuild.LinkName=Sphinx-build Warnungen
 Warnings.SphinxBuild.TrendName=Sphinx-build Warnungen Trend
+
+Warnings.RFLint.ParserName=RFLint
+Warnings.RFLint.LinkName=RFLint Warnungen
+Warnings.RFLint.TrendName=RFLint Warnungen Trend

--- a/src/test/java/hudson/plugins/warnings/parser/ParserRegistryIntegrationTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/ParserRegistryIntegrationTest.java
@@ -34,7 +34,7 @@ import hudson.plugins.analysis.util.model.FileAnnotation;
  */
 public class ParserRegistryIntegrationTest {
     /** If you add a new parser then this value needs to be adapted. */
-    private static final int NUMBER_OF_AVAILABLE_PARSERS = 65;
+    private static final int NUMBER_OF_AVAILABLE_PARSERS = 66;
     private static final String OLD_ID_ECLIPSE_JAVA_COMPILER = "Eclipse Java Compiler";
     private static final String JAVA_WARNINGS_FILE = "deprecations.txt";
     private static final String OLD_ID_JAVA_COMPILER = "Java Compiler";

--- a/src/test/java/hudson/plugins/warnings/parser/RFLintParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/RFLintParserTest.java
@@ -12,13 +12,14 @@ import java.util.Locale;
 import static org.junit.Assert.assertEquals;
 
 /**
+ * Tests the class {@link RFLintParser}.
  * Created by traitanit on 3/27/2017 AD.
  */
 public class RFLintParserTest extends ParserTester {
     private static final String WARNING_TYPE = Messages._Warnings_RFLint_ParserName().toString(Locale.ENGLISH);
 
     /**
-     * Parses a txt file, containing 3 warnings.
+     * Parses a txt file, containing 6 warnings.
      *
      * @throws IOException
      *      if the file could not be read
@@ -27,33 +28,47 @@ public class RFLintParserTest extends ParserTester {
     public void rfLintTest() throws IOException {
         Collection<FileAnnotation> warnings = new RFLintParser().parse(openFile());
 
-        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 3, warnings.size());
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 6, warnings.size());
         Iterator<FileAnnotation> iterator = warnings.iterator();
         FileAnnotation warning;
 
         warning = iterator.next();
         checkWarning(warning,
-                187,
-                "Found invalid variable name 'login_tmx_account_not_tmnId', " +
-                        "please name your variable using snake_case: 'login_tmx_account_not_tmn_id'",
-                "Login/Login.robot",
+                25,
+                "Line is too long (exceeds 100 characters)",
+                "./Login_to_web.robot",
                 WARNING_TYPE, "WARNING", Priority.NORMAL);
-
         warning = iterator.next();
         checkWarning(warning,
-                188,
-                "Found invalid variable name 'login_tmx_password_not_tmnId', " +
-                        "please name your variable using snake_case: 'login_tmx_password_not_tmn_id'",
-                "Login/Login.robot",
+                40,
+                "No keyword documentation",
+                "./Login_to_web.robot",
                 WARNING_TYPE, "ERROR", Priority.HIGH);
-
         warning = iterator.next();
         checkWarning(warning,
-                262,
-                "Found invalid variable name 'last9Digit', " +
-                        "please name your variable using snake_case: 'last9_digit'",
-                "Login/Login.robot",
+                24,
+                "Line is too long (exceeds 100 characters)",
+                "./Merchant_Signup.robot",
+                WARNING_TYPE, "WARNING", Priority.NORMAL);
+        warning = iterator.next();
+        checkWarning(warning,
+                378,
+                "No keyword documentation",
+                "./Merchant_Signup.robot",
+                WARNING_TYPE, "ERROR", Priority.HIGH);
+        warning = iterator.next();
+        checkWarning(warning,
+                73,
+                "Too few steps (1) in keyword",
+                "./merchant_common_keyword.txt",
+                WARNING_TYPE, "WARNING", Priority.NORMAL);
+        warning = iterator.next();
+        checkWarning(warning,
+                123,
+                "Ignore Error",
+                "./merchant_common_keyword.txt",
                 WARNING_TYPE, "IGNORE", Priority.LOW);
+
     }
 
     @Override

--- a/src/test/java/hudson/plugins/warnings/parser/RFLintParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/RFLintParserTest.java
@@ -1,0 +1,60 @@
+package hudson.plugins.warnings.parser;
+
+import hudson.plugins.analysis.util.model.FileAnnotation;
+import hudson.plugins.analysis.util.model.Priority;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by traitanit on 3/27/2017 AD.
+ */
+public class RFLintParserTest extends ParserTester {
+    private static final String WARNING_TYPE = Messages._Warnings_RFLint_ParserName().toString(Locale.ENGLISH);
+
+    /**
+     * Parses a txt file, containing 3 warnings.
+     *
+     * @throws IOException
+     *      if the file could not be read
+     */
+    @Test
+    public void rfLintTest() throws IOException {
+        Collection<FileAnnotation> warnings = new RFLintParser().parse(openFile());
+
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 3, warnings.size());
+        Iterator<FileAnnotation> iterator = warnings.iterator();
+        FileAnnotation warning;
+
+        warning = iterator.next();
+        checkWarning(warning,
+                11,
+                "test case 'Invalid Test Case Pattern'",
+                "rules/InvalidTestPattern.robot",
+                WARNING_TYPE, "E", Priority.HIGH);
+
+        warning = iterator.next();
+        checkWarning(warning,
+                65,
+                "Line is too long (exceeds 100 characters)",
+                "rules/GetProfile.txt",
+                WARNING_TYPE, "W", Priority.NORMAL);
+
+        warning = iterator.next();
+        checkWarning(warning,
+                28,
+                "Too many steps (32) in test case",
+                "CancelDebit/CancelDebit.txt",
+                WARNING_TYPE, "I", Priority.LOW);
+    }
+
+    @Override
+    protected String getWarningsFile() {
+        return "rflint.txt";
+    }
+}

--- a/src/test/java/hudson/plugins/warnings/parser/RFLintParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/RFLintParserTest.java
@@ -33,24 +33,27 @@ public class RFLintParserTest extends ParserTester {
 
         warning = iterator.next();
         checkWarning(warning,
-                11,
-                "test case 'Invalid Test Case Pattern'",
-                "rules/InvalidTestPattern.robot",
-                WARNING_TYPE, "E", Priority.HIGH);
+                187,
+                "Found invalid variable name 'login_tmx_account_not_tmnId', " +
+                        "please name your variable using snake_case: 'login_tmx_account_not_tmn_id'",
+                "Login/Login.robot",
+                WARNING_TYPE, "WARNING", Priority.NORMAL);
 
         warning = iterator.next();
         checkWarning(warning,
-                65,
-                "Line is too long (exceeds 100 characters)",
-                "rules/GetProfile.txt",
-                WARNING_TYPE, "W", Priority.NORMAL);
+                188,
+                "Found invalid variable name 'login_tmx_password_not_tmnId', " +
+                        "please name your variable using snake_case: 'login_tmx_password_not_tmn_id'",
+                "Login/Login.robot",
+                WARNING_TYPE, "ERROR", Priority.HIGH);
 
         warning = iterator.next();
         checkWarning(warning,
-                28,
-                "Too many steps (32) in test case",
-                "CancelDebit/CancelDebit.txt",
-                WARNING_TYPE, "I", Priority.LOW);
+                262,
+                "Found invalid variable name 'last9Digit', " +
+                        "please name your variable using snake_case: 'last9_digit'",
+                "Login/Login.robot",
+                WARNING_TYPE, "IGNORE", Priority.LOW);
     }
 
     @Override

--- a/src/test/resources/hudson/plugins/warnings/parser/rflint.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/rflint.txt
@@ -1,12 +1,5 @@
-**************************************************
-+ rules/InvalidTestPattern.robot
-rules/InvalidTestPattern.robot:11 [E]: test case 'Invalid Test Case Pattern' (0) (AcmTestCasePattern)
-**************************************************
-+ rules/GetProfile.txt
-rules/GetProfile.txt:65 [W]: Line is too long (exceeds 100 characters) (100) (LineTooLong)
-**************************************************
-+ CancelDebit/CancelDebit.txt
-CancelDebit/CancelDebit.txt:28 [I]: Too many steps (32) in test case (0) (TooManyTestSteps)
-**************************************************
-+ Login.robot
-Login.robot:278 [K]: No keyword documentation (0) (RequireKeywordDocumentation)
++ Login/Login.robot
+Login/Login.robot: W: 187, 0: Found invalid variable name 'login_tmx_account_not_tmnId', please name your variable using snake_case: 'login_tmx_account_not_tmn_id' (AcmSnakeCaseVariables)
+Login/Login.robot: E: 188, 0: Found invalid variable name 'login_tmx_password_not_tmnId', please name your variable using snake_case: 'login_tmx_password_not_tmn_id' (AcmSnakeCaseVariables)
+Login/Login.robot: I: 262, 0: Found invalid variable name 'last9Digit', please name your variable using snake_case: 'last9_digit' (AcmSnakeCaseVariables)
+Login/Login.robot: K: 265, 0: Found invalid variable name 'loginSecret', please name your variable using snake_case: 'login_secret' (AcmSnakeCaseVariables)

--- a/src/test/resources/hudson/plugins/warnings/parser/rflint.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/rflint.txt
@@ -1,5 +1,10 @@
-+ Login/Login.robot
-Login/Login.robot: W: 187, 0: Found invalid variable name 'login_tmx_account_not_tmnId', please name your variable using snake_case: 'login_tmx_account_not_tmn_id' (AcmSnakeCaseVariables)
-Login/Login.robot: E: 188, 0: Found invalid variable name 'login_tmx_password_not_tmnId', please name your variable using snake_case: 'login_tmx_password_not_tmn_id' (AcmSnakeCaseVariables)
-Login/Login.robot: I: 262, 0: Found invalid variable name 'last9Digit', please name your variable using snake_case: 'last9_digit' (AcmSnakeCaseVariables)
-Login/Login.robot: K: 265, 0: Found invalid variable name 'loginSecret', please name your variable using snake_case: 'login_secret' (AcmSnakeCaseVariables)
++ ./Login_to_web.robot
+W: 25, 100: Line is too long (exceeds 100 characters) (LineTooLong)
+E: 40, 0: No keyword documentation (RequireKeywordDocumentation)
++ ./Merchant_Signup.robot
+W: 24, 100: Line is too long (exceeds 100 characters) (LineTooLong)
+E: 378, 0: No keyword documentation (RequireKeywordDocumentation)
++ ./merchant_common_keyword.txt
+W: 73, 0: Too few steps (1) in keyword (TooFewKeywordSteps)
+I: 123, 0: Ignore Error (Ignore Error)
+K: 222, 0: Invalid Warning Type (Invalid Warning)

--- a/src/test/resources/hudson/plugins/warnings/parser/rflint.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/rflint.txt
@@ -1,0 +1,12 @@
+**************************************************
++ rules/InvalidTestPattern.robot
+rules/InvalidTestPattern.robot:11 [E]: test case 'Invalid Test Case Pattern' (0) (AcmTestCasePattern)
+**************************************************
++ rules/GetProfile.txt
+rules/GetProfile.txt:65 [W]: Line is too long (exceeds 100 characters) (100) (LineTooLong)
+**************************************************
++ CancelDebit/CancelDebit.txt
+CancelDebit/CancelDebit.txt:28 [I]: Too many steps (32) in test case (0) (TooManyTestSteps)
+**************************************************
++ Login.robot
+Login.robot:278 [K]: No keyword documentation (0) (RequireKeywordDocumentation)

--- a/warnings.iml
+++ b/warnings.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_6" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_6">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
@@ -9,26 +9,18 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/localizer" isTestSource="false" generated="true" />
-      <excludeFolder url="file://$MODULE_DIR$/target/checkout" />
-      <excludeFolder url="file://$MODULE_DIR$/target/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/target/generated-sources/groovy-stubs" />
-      <excludeFolder url="file://$MODULE_DIR$/target/jenkins-for-test" />
-      <excludeFolder url="file://$MODULE_DIR$/target/jenkins-for-testx" />
-      <excludeFolder url="file://$MODULE_DIR$/target/maven-status" />
-      <excludeFolder url="file://$MODULE_DIR$/target/surefire-reports" />
-      <excludeFolder url="file://$MODULE_DIR$/target/test-classes" />
-      <excludeFolder url="file://$MODULE_DIR$/target/warnings" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Maven: org.jvnet.hudson.plugins:analysis-core:1.82" level="project" />
-    <orderEntry type="library" name="Maven: org.jenkins-ci.plugins:script-security:1.17" level="project" />
-    <orderEntry type="library" name="Maven: org.jvnet.hudson.plugins:analysis-core:1.82" level="project" />
+    <orderEntry type="library" name="Maven: org.jvnet.hudson.plugins:analysis-core:1.84" level="project" />
     <orderEntry type="library" name="Maven: de.java2html:java2html:5.0" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.3.2" level="project" />
     <orderEntry type="library" name="Maven: xerces:xercesImpl:2.11.0" level="project" />
     <orderEntry type="library" name="Maven: xml-apis:xml-apis:1.4.01" level="project" />
     <orderEntry type="library" name="Maven: joda-time:joda-time:1.6" level="project" />
+    <orderEntry type="library" name="Maven: org.jenkins-ci.plugins:structs:1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.jenkins-ci:symbol-annotation:1.2" level="project" />
     <orderEntry type="library" name="Maven: org.jenkins-ci.plugins:violations:0.7.11" level="project" />
     <orderEntry type="library" name="Maven: xpp3:xpp3:1.1.3.3" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-digester3:3.2" level="project" />
@@ -208,7 +200,7 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: net.sf.ezmorph:ezmorph:1.0.6" level="project" />
     <orderEntry type="library" name="Maven: commons-httpclient:commons-httpclient:3.1" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: args4j:args4j:2.0.31" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.jenkins-ci:annotation-indexer:1.7" level="project" />
+    <orderEntry type="library" name="Maven: org.jenkins-ci:annotation-indexer:1.7" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.jenkins-ci:bytecode-compatibility-transformer:1.5" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.kohsuke:asm5:5.0.1" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.jenkins-ci:task-reactor:1.4" level="project" />


### PR DESCRIPTION
Support [Robot Framework](http://robotframework.org/) syntax based on [Robot Framework Lint](https://github.com/boakley/robotframework-lint/wiki) project.

Usage:
```
cmd$ pip install robotframework-lint
cmd$ rflint path/to/robot/files | tee robot.log
```

Then parse `robot.log` to warnings-plugin