### PR TITLE
Parse parallel pipeline output for Javac

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/JavacParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/JavacParser.java
@@ -17,7 +17,7 @@ public class JavacParser extends RegexpLineParser {
     static final String JAVA_LARGE_ICON = WarningsDescriptor.IMAGE_PREFIX + "java-48x48.png";
 
     private static final long serialVersionUID = 7199325311690082782L;
-    private static final String JAVAC_WARNING_PATTERN = "^(?:\\[WARNING\\]\\s+)?([^\\[]*):\\[(\\d+)[.,;]*(\\d+)?\\]\\s*(?:\\[(\\w+)\\])?\\s*(.*)$";
+    private static final String JAVAC_WARNING_PATTERN = "^(?:\\[\\p{Alnum}*\\]\\s+)?(?:\\[WARNING\\]\\s+)?([^\\[]*):\\[(\\d+)[.,;]*(\\d+)?\\]\\s*(?:\\[(\\w+)\\])?\\s*(.*)$";
 
     /**
      * Creates a new instance of {@link JavacParser}.

--- a/src/test/java/hudson/plugins/warnings/parser/JavacParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/JavacParserTest.java
@@ -91,6 +91,18 @@ public class JavacParserTest extends ParserTester {
                 WARNING_TYPE, "Deprecation", Priority.NORMAL);
     }
 
+    /**
+     * Parses parallel pipeline output based on 'javac.txt'
+     *
+     * @throws IOException Signals that an I/O exception has occurred.
+     */
+    @Test
+    public void parseParallelPipelineOutput() throws IOException {
+        Collection<FileAnnotation> warnings = parse("javac-parallel-pipeline.txt");
+
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 2, warnings.size());
+    }
+
     private Collection<FileAnnotation> parse(final String fileName) throws IOException {
         return new JavacParser().parse(openFile(fileName));
     }

--- a/src/test/java/hudson/plugins/warnings/parser/JavacParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/JavacParserTest.java
@@ -1,6 +1,7 @@
 package hudson.plugins.warnings.parser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Locale;
@@ -101,6 +102,19 @@ public class JavacParserTest extends ParserTester {
         Collection<FileAnnotation> warnings = parse("javac-parallel-pipeline.txt");
 
         assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 2, warnings.size());
+
+        String fileName = "C:/Build/Results/jobs/ADT-Base/workspace/com.avaloq.adt.ui/src/main/java/com/avaloq/adt/ui/elements/AvaloqDialog.java";
+        Iterator<Warning> expectedWarnings = Arrays.asList(
+                new Warning(fileName, 12, WARNING_TYPE, "Deprecation", "org.eclipse.jface.contentassist.SubjectControlContentAssistant in org.eclipse.jface.contentassist has been deprecated"),
+                new Warning(fileName, 40, WARNING_TYPE, "Deprecation", "org.eclipse.ui.contentassist.ContentAssistHandler in org.eclipse.ui.contentassist has been deprecated")
+                ).iterator();
+
+        Iterator<FileAnnotation> iterator = warnings.iterator();
+        while (iterator.hasNext()) {
+            assertTrue(WRONG_NUMBER_OF_WARNINGS_DETECTED, expectedWarnings.hasNext());
+            Warning expectedWarning = expectedWarnings.next();
+            checkWarning(iterator.next(), expectedWarning.getPrimaryLineNumber(), expectedWarning.getMessage(), expectedWarning.getFileName(), expectedWarning.getType(), expectedWarning.getCategory(), expectedWarning.getPriority());
+        }
     }
 
     private Collection<FileAnnotation> parse(final String fileName) throws IOException {

--- a/src/test/resources/hudson/plugins/warnings/parser/javac-parallel-pipeline.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/javac-parallel-pipeline.txt
@@ -1,0 +1,77 @@
+[ParallelStep] started
+[ParallelStep] [workspace] $ mvn.bat clean compile -DeclipseTarget=C:/Build/Results/jobs/ADT-Base-Target/workspace/eclipse
+[ParallelStep] [INFO] [clean:clean]
+[ParallelStep] [INFO] Deleting directory C:\Build\Results\jobs\ADT-Base\workspace\com.avaloq.adt.ui\target
+[ParallelStep] [INFO] Deleting directory C:\Build\Results\jobs\ADT-Base\workspace\com.avaloq.adt.ui\target\classes
+[ParallelStep] [INFO] Deleting directory C:\Build\Results\jobs\ADT-Base\workspace\com.avaloq.adt.ui\target\test-classes
+[ParallelStep] [INFO] Deleting directory C:\Build\Results\jobs\ADT-Base\workspace\com.avaloq.adt.ui\target\site
+[ParallelStep] [INFO] [resources:resources]
+[ParallelStep] [INFO] Using default encoding to copy filtered resources.
+[ParallelStep] [INFO] [psteclipse:update {execution: update}]
+[ParallelStep] [INFO] Defaulting prefixes to the single prefix 'com.avaloq.'.
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant/1.7.0/org.apache.ant-1.7.0.jar
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant/1.7.0/org.apache.ant-1.7.0.jar
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant/1.7.0/org.apache.ant.ant-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant/1.7.0/org.apache.ant.ant-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-antlr/1.7.0/org.apache.ant.ant-antlr-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-antlr/1.7.0/org.apache.ant.ant-antlr-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-apache-bcel/1.7.0/org.apache.ant.ant-apache-bcel-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-apache-bcel/1.7.0/org.apache.ant.ant-apache-bcel-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-apache-bsf/1.7.0/org.apache.ant.ant-apache-bsf-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-apache-bsf/1.7.0/org.apache.ant.ant-apache-bsf-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-apache-log4j/1.7.0/org.apache.ant.ant-apache-log4j-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-apache-log4j/1.7.0/org.apache.ant.ant-apache-log4j-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-apache-oro/1.7.0/org.apache.ant.ant-apache-oro-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-apache-oro/1.7.0/org.apache.ant.ant-apache-oro-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-apache-regexp/1.7.0/org.apache.ant.ant-apache-regexp-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-apache-regexp/1.7.0/org.apache.ant.ant-apache-regexp-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-apache-resolver/1.7.0/org.apache.ant.ant-apache-resolver-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-apache-resolver/1.7.0/org.apache.ant.ant-apache-resolver-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-commons-logging/1.7.0/org.apache.ant.ant-commons-logging-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-commons-logging/1.7.0/org.apache.ant.ant-commons-logging-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-commons-net/1.7.0/org.apache.ant.ant-commons-net-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-commons-net/1.7.0/org.apache.ant.ant-commons-net-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-jai/1.7.0/org.apache.ant.ant-jai-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-jai/1.7.0/org.apache.ant.ant-jai-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-javamail/1.7.0/org.apache.ant.ant-javamail-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-javamail/1.7.0/org.apache.ant.ant-javamail-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-jdepend/1.7.0/org.apache.ant.ant-jdepend-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-jdepend/1.7.0/org.apache.ant.ant-jdepend-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-jmf/1.7.0/org.apache.ant.ant-jmf-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-jmf/1.7.0/org.apache.ant.ant-jmf-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-jsch/1.7.0/org.apache.ant.ant-jsch-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-jsch/1.7.0/org.apache.ant.ant-jsch-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-junit/1.7.0/org.apache.ant.ant-junit-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-junit/1.7.0/org.apache.ant.ant-junit-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-launcher/1.7.0/org.apache.ant.ant-launcher-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-launcher/1.7.0/org.apache.ant.ant-launcher-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-netrexx/1.7.0/org.apache.ant.ant-netrexx-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-netrexx/1.7.0/org.apache.ant.ant-netrexx-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-nodeps/1.7.0/org.apache.ant.ant-nodeps-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-nodeps/1.7.0/org.apache.ant.ant-nodeps-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-starteam/1.7.0/org.apache.ant.ant-starteam-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-starteam/1.7.0/org.apache.ant.ant-starteam-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-stylebook/1.7.0/org.apache.ant.ant-stylebook-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-stylebook/1.7.0/org.apache.ant.ant-stylebook-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-swing/1.7.0/org.apache.ant.ant-swing-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-swing/1.7.0/org.apache.ant.ant-swing-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-trax/1.7.0/org.apache.ant.ant-trax-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-trax/1.7.0/org.apache.ant.ant-trax-1.7.0.pom
+[ParallelStep] Downloading: http://download.java.net/maven/2//com/avaloq/adt/org.apache.ant.ant-weblogic/1.7.0/org.apache.ant.ant-weblogic-1.7.0.pom
+[ParallelStep] Downloading: http://repo1.maven.org/maven2/com/avaloq/adt/org.apache.ant.ant-weblogic/1.7.0/org.apache.ant.ant-weblogic-1.7.0.pom
+[ParallelStep] [INFO] [compiler:compile]
+[ParallelStep] [INFO] Compiling 981 source files to C:\Build\Results\jobs\ADT-Base\workspace\com.avaloq.adt.ui\target\classes
+[ParallelStep] 
+[ParallelStep] [WARNING] C:\Build\Results\jobs\ADT-Base\workspace\com.avaloq.adt.ui\src\main\java\com\avaloq\adt\ui\elements\AvaloqDialog.java:[12,39] [deprecation] org.eclipse.jface.contentassist.SubjectControlContentAssistant in org.eclipse.jface.contentassist has been deprecated
+[ParallelStep] 
+[ParallelStep] [WARNING] C:\Build\Results\jobs\ADT-Base\workspace\com.avaloq.adt.ui\src\main\java\com\avaloq\adt\ui\elements\AvaloqDialog.java:[40,36] [deprecation] org.eclipse.ui.contentassist.ContentAssistHandler in org.eclipse.ui.contentassist has been deprecated
+[ParallelStep] 
+[ParallelStep] [FINDBUGS] Collecting findbugs analysis files...
+[ParallelStep] [FINDBUGS] No annotations have been found.
+[ParallelStep] [PMD] Collecting pmd analysis files...
+[ParallelStep] [PMD] No annotations have been found.
+[ParallelStep] [TASKS] Scanning workspace files for tasks...
+[ParallelStep] [TASKS] A total of 555 annotations have been found.
+[ParallelStep] [WARNINGS] Parsing warnings of log file...
+[ParallelStep] [WARNINGS] A total of 105 annotations have been found.
+[ParallelStep] finished: SUCCESS


### PR DESCRIPTION
Jenkins parallel pipeline builds add the name of the parallel step to the log output ('[ParallelStepName] ...'). The Javac parser can now correctly handle parallel pipeline build output.