### PR TITLE
[Feature] Category filtering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>warnings</artifactId>
   <packaging>hpi</packaging>
   <name>Warnings Plug-in</name>
-  <version>4.61-SNAPSHOT</version>
+  <version>4.61</version>
   <url>http://wiki.jenkins-ci.org/x/G4CGAQ</url>
   <description>This plug-in reads the compiler warnings from the console log file and generates a trend report.</description>
 
@@ -118,7 +118,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>HEAD</tag>
+    <tag>warnings-4.61</tag>
   </scm>
 
   <repositories>

--- a/src/main/java/hudson/plugins/warnings/WarningsPublisher.java
+++ b/src/main/java/hudson/plugins/warnings/WarningsPublisher.java
@@ -60,6 +60,8 @@ public class WarningsPublisher extends HealthAwarePublisher implements SimpleBui
     private String excludePattern;
     /** warning messages to exclude from report */
     private String messagesPattern;
+    /** warning categories to exclude from report */
+    private String categoriesPattern;
 	
     /** File pattern and parser configurations. @since 3.19 */
     @SuppressFBWarnings("SE")
@@ -168,6 +170,15 @@ public class WarningsPublisher extends HealthAwarePublisher implements SimpleBui
     }
 
     /**
+     * Returns the Java regex pattern of warning categories to exclude from report.
+     *
+     * @return the Java regex pattern of warning categories to exclude from report
+     */
+    public String getCategoriesPattern() {
+        return categoriesPattern;
+    }
+
+    /**
      * Sets the Java regex pattern of warning messages to exclude from report.
      *
      * @param pattern the pattern to exclude
@@ -175,6 +186,16 @@ public class WarningsPublisher extends HealthAwarePublisher implements SimpleBui
     @DataBoundSetter
     public void setMessagesPattern(final String pattern) {
         messagesPattern = pattern;
+    }
+
+    /**
+     * Sets the Java regex pattern of warning categories to exclude from report.
+     *
+     * @param pattern the pattern to exclude
+     */
+    @DataBoundSetter
+    public void setCategoriesPattern(final String pattern) {
+        categoriesPattern = pattern;
     }
 
     /**
@@ -361,9 +382,9 @@ public class WarningsPublisher extends HealthAwarePublisher implements SimpleBui
 
     private ParserResult filterWarnings(final ParserResult project, final PluginLogger logger) {
         WarningsFilter filter = new WarningsFilter();
-        if (filter.isActive(getIncludePattern(), getExcludePattern(), getMessagesPattern())) {
+        if (filter.isActive(getIncludePattern(), getExcludePattern(), getMessagesPattern(), getCategoriesPattern())) {
             Collection<FileAnnotation> filtered = filter.apply(project.getAnnotations(),
-                    getIncludePattern(), getExcludePattern(), getMessagesPattern(), logger);
+                    getIncludePattern(), getExcludePattern(), getMessagesPattern(), getCategoriesPattern(), logger);
             return new ParserResult(filtered);
         }
         return project;

--- a/src/main/java/hudson/plugins/warnings/parser/WarningsFilter.java
+++ b/src/main/java/hudson/plugins/warnings/parser/WarningsFilter.java
@@ -24,7 +24,7 @@ public class WarningsFilter {
     private Set<Pattern> addFilePatterns(final @CheckForNull String pattern) {
         Set<Pattern> patterns = Sets.newHashSet();
         if (StringUtils.isNotBlank(pattern)) {
-            String[] split = StringUtils.split(pattern, '\n');
+            String[] split = StringUtils.split(pattern, ',');
             for (String singlePattern : split) {
                 String trimmed = StringUtils.trim(singlePattern);
                 String directoriesReplaced = StringUtils.replace(trimmed, "**", "*"); // NOCHECKSTYLE
@@ -104,7 +104,7 @@ public class WarningsFilter {
                     }
                 }
                 for (Pattern exclude : categoriesPatterns) {
-                    if (exclude.matcher(annotation.getMessage()).matches()) {
+                    if (exclude.matcher(annotation.getCategory()).matches()) {
                         excludedAnnotations.remove(annotation);
                     }
                 }

--- a/src/main/java/hudson/plugins/warnings/parser/WarningsFilter.java
+++ b/src/main/java/hudson/plugins/warnings/parser/WarningsFilter.java
@@ -21,14 +21,26 @@ public class WarningsFilter {
     private final Set<Pattern> includePatterns = Sets.newHashSet();
     private final Set<Pattern> excludePatterns = Sets.newHashSet();
 
-    private Set<Pattern> addPatterns(final @CheckForNull String pattern) {
+    private Set<Pattern> addFilePatterns(final @CheckForNull String pattern) {
         Set<Pattern> patterns = Sets.newHashSet();
         if (StringUtils.isNotBlank(pattern)) {
-            String[] split = StringUtils.split(pattern, ',');
+            String[] split = StringUtils.split(pattern, '\n');
             for (String singlePattern : split) {
                 String trimmed = StringUtils.trim(singlePattern);
                 String directoriesReplaced = StringUtils.replace(trimmed, "**", "*"); // NOCHECKSTYLE
                 patterns.add(Pattern.compile(StringUtils.replace(directoriesReplaced, "*", ".*"))); // NOCHECKSTYLE
+            }
+        }
+        return patterns;
+    }
+
+    private Set<Pattern> addStringPatterns(final @CheckForNull String pattern) {
+        Set<Pattern> patterns = Sets.newHashSet();
+        if (StringUtils.isNotBlank(pattern)) {
+            String[] split = StringUtils.split(pattern, '\n');
+            for (String singlePattern : split) {
+                String trimmed = StringUtils.trim(singlePattern);
+                patterns.add(Pattern.compile(trimmed)); // NOCHECKSTYLE
             }
         }
         return patterns;
@@ -54,10 +66,12 @@ public class WarningsFilter {
                                      final @CheckForNull String includePattern,
                                      final @CheckForNull String excludePattern,
                                      final @CheckForNull String messagesPattern,
+                                     final @CheckForNull String categoriesPattern,
                                      final PluginLogger logger) {
-        Collection<Pattern> includePatterns = addPatterns(includePattern);
-        Collection<Pattern> excludePatterns = addPatterns(excludePattern);
-        Collection<Pattern> messagesPatterns = addPatterns(messagesPattern);
+        Collection<Pattern> includePatterns = addFilePatterns(includePattern);
+        Collection<Pattern> excludePatterns = addFilePatterns(excludePattern);
+        Collection<Pattern> messagesPatterns = addStringPatterns(messagesPattern);
+        Collection<Pattern> categoriesPatterns = addStringPatterns(categoriesPattern);
 
         Collection<FileAnnotation> includedAnnotations;
         if (includePatterns.isEmpty()) {
@@ -73,7 +87,7 @@ public class WarningsFilter {
                 }
             }
         }
-        if (excludePatterns.isEmpty() && messagesPatterns.isEmpty()) {
+        if (excludePatterns.isEmpty() && messagesPatterns.isEmpty() && categoriesPatterns.isEmpty()) {
             return includedAnnotations;
         }
         else {
@@ -89,13 +103,18 @@ public class WarningsFilter {
                         excludedAnnotations.remove(annotation);
                     }
                 }
+                for (Pattern exclude : categoriesPatterns) {
+                    if (exclude.matcher(annotation.getMessage()).matches()) {
+                        excludedAnnotations.remove(annotation);
+                    }
+                }
             }
             logger.log(String.format("Found %d warnings after exclusion.", excludedAnnotations.size()));
             return excludedAnnotations;
         }
     }
 
-    public boolean isActive(final String includePattern, final String excludePattern, final String messagesPattern) {
-        return StringUtils.isNotBlank(includePattern) || StringUtils.isNotBlank(excludePattern) || StringUtils.isNotBlank(messagesPattern);
+    public boolean isActive(final String includePattern, final String excludePattern, final String messagesPattern, final String categoriesPattern) {
+        return StringUtils.isNotBlank(includePattern) || StringUtils.isNotBlank(excludePattern) || StringUtils.isNotBlank(messagesPattern) || StringUtils.isNotBlank(categoriesPattern);
     }
 }

--- a/src/main/resources/hudson/plugins/warnings/WarningsPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/warnings/WarningsPublisher/config.jelly
@@ -15,10 +15,10 @@
 
   <f:advanced>
     <f:entry title="${%Warnings to include}" field="includePattern" description="${%description.includePattern}">
-      <f:expandableTextbox />
+      <f:textbox />
     </f:entry>
     <f:entry title="${%Warnings to ignore}" field="excludePattern" description="${%description.excludePattern}">
-      <f:expandableTextbox />
+      <f:textbox />
     </f:entry>
     <f:entry title="${%Messages to ignore}" field="messagesPattern" description="${%description.messagesPattern}">
       <f:expandableTextbox />

--- a/src/main/resources/hudson/plugins/warnings/WarningsPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/warnings/WarningsPublisher/config.jelly
@@ -15,13 +15,16 @@
 
   <f:advanced>
     <f:entry title="${%Warnings to include}" field="includePattern" description="${%description.includePattern}">
-      <f:textbox />
+      <f:expandableTextbox />
     </f:entry>
     <f:entry title="${%Warnings to ignore}" field="excludePattern" description="${%description.excludePattern}">
-      <f:textbox />
+      <f:expandableTextbox />
     </f:entry>
     <f:entry title="${%Messages to ignore}" field="messagesPattern" description="${%description.messagesPattern}">
-      <f:textbox />
+      <f:expandableTextbox />
+    </f:entry>
+    <f:entry title="${%Categories to ignore}" field="categoriesPattern" description="${%description.categoriesPattern}">
+      <f:expandableTextbox />
     </f:entry>
 
     <u:failed />

--- a/src/main/resources/hudson/plugins/warnings/WarningsPublisher/config.properties
+++ b/src/main/resources/hudson/plugins/warnings/WarningsPublisher/config.properties
@@ -7,17 +7,21 @@ description.consoleLogParsers=The parsers to use when scanning the console log o
 description.logFilesParsers=Workspace files to scan for compiler warnings using a predefined parser. \
                  If none of the parsers fits your project then you can create your own parser in the \
                  <a href="../../configure">system configuration</a> section.
-description.includePattern=Comma separated list of \
-                 <a href="http://download.oracle.com/javase/1.5.0/docs/api/java/util/regex/Pattern.html">regular expressions</a> \
-                 that specifies the files to include in the report (based on their absolute filename). \
+description.includePattern=List of \
+                 <a href="http://download.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">regular expressions</a> \
+                 (one per line) that specifies the files to include in the report (based on their absolute filename). \
                  If this field is empty then all files are included.
-description.excludePattern=Comma separated list of \
-                 <a href="http://download.oracle.com/javase/1.5.0/docs/api/java/util/regex/Pattern.html">regular expressions</a> \
-                 that specifies the files to exclude from the report (based on their absolute filename).
-description.messagesPattern=Comma separated list of \
-                 <a href="http://download.oracle.com/javase/1.5.0/docs/api/java/util/regex/Pattern.html">regular expressions</a>, \
-                 that specifies the warning messages to exclude form the report (based on the warning messages). \
+description.excludePattern=List of \
+                 <a href="http://download.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">regular expressions</a> \
+                 (one per line) that specifies the files to exclude from the report (based on their absolute filename).
+description.messagesPattern=List of \
+                 <a href="http://download.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">regular expressions</a>, \
+                 (one per line) that specifies the warning messages to exclude form the report (based on the warning messages). \
                  If this field is empty then all warning messages are included.
+description.categoriesPattern=List of \
+                 <a href="http://download.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">regular expressions</a>, \
+                 (one per line) that specifies the warning messages to exclude form the report (based on the warning categories). \
+                 If this field is empty then all warning categories are included.
                 
 description.detectModules=Determines if Ant or Maven modules should be detected for all files that contain \
         warnings. Activating this option may increase your build time since the detector scans the whole \

--- a/src/main/resources/hudson/plugins/warnings/WarningsPublisher/config_de.properties
+++ b/src/main/resources/hudson/plugins/warnings/WarningsPublisher/config_de.properties
@@ -2,19 +2,24 @@ description.consoleLogParsers=Diese Parser werden zum Analysieren der Konsolenau
                  Falls kein Parser ausgewählt wird, wird die Konsolenausgabe nicht untersucht. 
 description.logFilesParsers=Dateien aus dem Arbeitsbereich, die mit einem festdefiniertem Parser durchsucht werden sollen.
                 
-description.includePattern=Komma separierte Liste von \
-                 <a href="http://download.oracle.com/javase/1.5.0/docs/api/java/util/regex/Pattern.html">regulären Ausdrücken</a>, \
+description.includePattern=Liste von \
+                 <a href="http://download.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">regulären Ausdrücken</a>, \
                  die die Warnungen festlegt, die im Warnungsbericht erscheinen sollen (basierend auf deren Dateinamen). \
                  Bleibt das Feld leer, so werden alle gefundenen Warnungen übernommen.
 description.excludePattern=Komma separierte Liste von \
-                 <a href="http://download.oracle.com/javase/1.5.0/docs/api/java/util/regex/Pattern.html">regulären Ausdrücken</a>, \
+                 <a href="http://download.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">regulären Ausdrücken</a>, \
                  die die Warnungen festlegt, die nicht im Warnungsbericht erscheinen sollen (basierend auf deren Dateinamen). \
                  Bleibt das Feld leer, so werden alle gefundenen Warnungen übernommen.
 description.messagesPattern=Komma separierte Liste von \
-                 <a href="http://download.oracle.com/javase/1.5.0/docs/api/java/util/regex/Pattern.html">regulären Ausdrücken</a>, \
+                 <a href="http://download.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">regulären Ausdrücken</a>, \
                  die die Warnungen festlegt, die nicht im Warnungsbericht erscheinen sollen (basierend auf deren Warnmeldungen). \
                  Bleibt das Feld leer, so werden alle gefundenen Warnungen übernommen.
-                 
+description.categoriesPattern=Komma separierte Liste von \
+                 <a href="http://download.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">regulären Ausdrücken</a>, \
+                 die die Warnungen festlegt, die nicht im Warnungsbericht erscheinen sollen (basierend auf deren Kategorien). \
+                 Bleibt das Feld leer, so werden alle gefundenen Warnungen übernommen.
+
+Categories\ to\ ignore=Zu ignorierende Warnungskategorien             
 Messages\ to\ ignore=Zu ignorierende Warnmeldungen
 Warnings\ to\ ignore=Zu ignorierende Warnungen
 Warnings\ to\ include=Zu berücksichtigende Warnungen

--- a/src/main/resources/hudson/plugins/warnings/WarningsPublisher/config_de.properties
+++ b/src/main/resources/hudson/plugins/warnings/WarningsPublisher/config_de.properties
@@ -10,13 +10,13 @@ description.excludePattern=Komma separierte Liste von \
                  <a href="http://download.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">regulären Ausdrücken</a>, \
                  die die Warnungen festlegt, die nicht im Warnungsbericht erscheinen sollen (basierend auf deren Dateinamen). \
                  Bleibt das Feld leer, so werden alle gefundenen Warnungen übernommen.
-description.messagesPattern=Komma separierte Liste von \
+description.messagesPattern=Liste von \
                  <a href="http://download.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">regulären Ausdrücken</a>, \
-                 die die Warnungen festlegt, die nicht im Warnungsbericht erscheinen sollen (basierend auf deren Warnmeldungen). \
+                 (einer pro Zeile) die die Warnungen festlegt, die nicht im Warnungsbericht erscheinen sollen (basierend auf deren Warnmeldungen). \
                  Bleibt das Feld leer, so werden alle gefundenen Warnungen übernommen.
-description.categoriesPattern=Komma separierte Liste von \
+description.categoriesPattern=Liste von \
                  <a href="http://download.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">regulären Ausdrücken</a>, \
-                 die die Warnungen festlegt, die nicht im Warnungsbericht erscheinen sollen (basierend auf deren Kategorien). \
+                 (einer pro Zeile) die die Warnungen festlegt, die nicht im Warnungsbericht erscheinen sollen (basierend auf deren Kategorien). \
                  Bleibt das Feld leer, so werden alle gefundenen Warnungen übernommen.
 
 Categories\ to\ ignore=Zu ignorierende Warnungskategorien             

--- a/src/test/java/hudson/plugins/warnings/parser/ParserRegistryTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/ParserRegistryTest.java
@@ -115,7 +115,8 @@ public class ParserRegistryTest {
                                                       final String includePattern, final String excludePattern) throws IOException {
         Collection<FileAnnotation> annotations = parserRegistry.parse(file);
         final String messagesPattern = null;
-        return new WarningsFilter().apply(annotations, includePattern, excludePattern, messagesPattern, new NullLogger());
+        final String categoriesPattern = null;
+        return new WarningsFilter().apply(annotations, includePattern, excludePattern, messagesPattern, categoriesPattern, new NullLogger());
     }
 
     /**

--- a/src/test/java/hudson/plugins/warnings/parser/WarningsFilterTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/WarningsFilterTest.java
@@ -50,7 +50,7 @@ public class WarningsFilterTest {
 
         WarningsFilter filter = new WarningsFilter();
         // exclude warnings with this warning message from the report
-        final String excludeCategory = ".*pragma-messages.*";
+        final String excludeCategory = "-W#pragma-messages";
         warnings = filter.apply(warnings, null, null, null, excludeCategory, new NullLogger());
 
         assertFalse(warnings.contains(w1));

--- a/src/test/java/hudson/plugins/warnings/parser/WarningsFilterTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/WarningsFilterTest.java
@@ -31,7 +31,27 @@ public class WarningsFilterTest {
         WarningsFilter filter = new WarningsFilter();
         // exclude warnings with this warning message from the report
         final String excludeMessage = "Javadoc: Missing tag for parameter arg1";
-        warnings = filter.apply(warnings, null, null, excludeMessage, new NullLogger());
+        warnings = filter.apply(warnings, null, null, excludeMessage, null, new NullLogger());
+
+        assertFalse(warnings.contains(w1));
+        assertTrue(warnings.contains(w2));
+    }
+
+    /**
+     * Tests the exclusion of certain warning messages from the report (based on category).
+     */
+    @Test
+    public void testMessagesPattern() {
+        Warning w1 = new Warning("dummyFile.java", 0, "warningType", "-W#pragma-messages", "Warning. But ok.", Priority.LOW);
+        Warning w2 = new Warning("dummyFile.java", 0, "warningType", "-WWhatever", "Warning. Not ok!", Priority.LOW);
+        Collection<FileAnnotation> warnings = new LinkedList<FileAnnotation>();
+        warnings.add(w1);
+        warnings.add(w2);
+
+        WarningsFilter filter = new WarningsFilter();
+        // exclude warnings with this warning message from the report
+        final String excludeCategory = ".*pragma-messages.*";
+        warnings = filter.apply(warnings, null, null, null, excludeCategory, new NullLogger());
 
         assertFalse(warnings.contains(w1));
         assertTrue(warnings.contains(w2));
@@ -40,5 +60,6 @@ public class WarningsFilterTest {
     private Warning createDummyWarning(final String message) {
         return new Warning("dummyFile.java", 0, "warningType", "warningCategory", message, Priority.LOW);
     }
+
 }
 

--- a/src/test/java/hudson/plugins/warnings/parser/WarningsFilterTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/WarningsFilterTest.java
@@ -41,7 +41,7 @@ public class WarningsFilterTest {
      * Tests the exclusion of certain warning messages from the report (based on category).
      */
     @Test
-    public void testMessagesPattern() {
+    public void testCategoriesPattern() {
         Warning w1 = new Warning("dummyFile.java", 0, "warningType", "-W#pragma-messages", "Warning. But ok.", Priority.LOW);
         Warning w2 = new Warning("dummyFile.java", 0, "warningType", "-WWhatever", "Warning. Not ok!", Priority.LOW);
         Collection<FileAnnotation> warnings = new LinkedList<FileAnnotation>();


### PR DESCRIPTION
- Adds option to filter by category.
- Removes strange regex conversion for the non-file-based options.
I know this might break existing jobs but in my opinion it is just wrong and could be considered a bug. You can not use commas in the regex, it is not a real regex etc.

Includes a small unit test and was tested on our local instance with GCC and Clang parsers.
