### PR TITLE
parsers: Implement a RT-Tests parser

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/RTTestsParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/RTTestsParser.java
@@ -2,9 +2,11 @@ package hudson.plugins.warnings.parser;
 
 import java.util.regex.Matcher;
 
-import hudson.Extension;
+import org.apache.commons.lang.StringUtils;
 
+import hudson.Extension;
 import hudson.plugins.analysis.util.model.Priority;
+
 
 /**
  * A parser for RTTests Error Messages.
@@ -31,12 +33,17 @@ public class RTTestsParser extends RegexpLineParser {
 
     @Override
     protected Warning createWarning(final Matcher matcher) {
-        String category = matcher.group(1).trim();
-        String message = matcher.group(3).trim();
+        String category = StringUtils.trim(matcher.group(1));
+        String message = StringUtils.trim(matcher.group(3));
         Priority priority = Priority.NORMAL;
 
-        if (category.equals("FATAL"))
+        if (category == null | message == null) {
+            return FALSE_POSITIVE;
+        }
+
+        if ("FATAL".equals(category)) {
             priority = Priority.HIGH;
+        }
 
         return createWarning("Nil", 0, category, message, priority);
     }

--- a/src/main/java/hudson/plugins/warnings/parser/RTTestsParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/RTTestsParser.java
@@ -13,31 +13,31 @@ import hudson.plugins.analysis.util.model.Priority;
  */
 @Extension
 public class RTTestsParser extends RegexpLineParser {
-	private static final long serialVersionUID = 2993328034978892249L;
+    private static final long serialVersionUID = 2993328034978892249L;
 
-	/** Pattern of perforce compiler warnings. */
-	private static final String CYCLICTEST_WARNING_PATTERN =
-		"^(WARN(ING)?|FATAL):(.*)$";
+    /** Pattern of RTTests warnings. */
+    private static final String CYCLICTEST_WARNING_PATTERN =
+        "^(WARN(ING)?|FATAL):(.*)$";
 
-	/**
+    /**
      * Creates a new instance of {@link RTTestsParser}.
      */
-	public RTTestsParser() {
-		super(Messages._Warnings_RTTests_ParserName(),
-			  Messages._Warnings_RTTests_LinkName(),
-			  Messages._Warnings_RTTests_TrendName(),
-			  CYCLICTEST_WARNING_PATTERN, true);
-	}
+    public RTTestsParser() {
+        super(Messages._Warnings_RTTests_ParserName(),
+              Messages._Warnings_RTTests_LinkName(),
+              Messages._Warnings_RTTests_TrendName(),
+              CYCLICTEST_WARNING_PATTERN, true);
+    }
 
-	@Override
-	protected Warning createWarning(final Matcher matcher) {
-		String category = matcher.group(1).trim();
-		String message = matcher.group(3).trim();
-		Priority priority = Priority.NORMAL;
+    @Override
+    protected Warning createWarning(final Matcher matcher) {
+        String category = matcher.group(1).trim();
+        String message = matcher.group(3).trim();
+        Priority priority = Priority.NORMAL;
 
-		if (category.equals("FATAL"))
-			priority = Priority.HIGH;
+        if (category.equals("FATAL"))
+            priority = Priority.HIGH;
 
-		return createWarning("Nil", 0, category, message, priority);
-	}
+        return createWarning("Nil", 0, category, message, priority);
+    }
 }

--- a/src/main/java/hudson/plugins/warnings/parser/RTTestsParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/RTTestsParser.java
@@ -1,0 +1,43 @@
+package hudson.plugins.warnings.parser;
+
+import java.util.regex.Matcher;
+
+import hudson.Extension;
+
+import hudson.plugins.analysis.util.model.Priority;
+
+/**
+ * A parser for RTTests Error Messages.
+ *
+ * @author Benedikt Spranger
+ */
+@Extension
+public class RTTestsParser extends RegexpLineParser {
+	private static final long serialVersionUID = 2993328034978892249L;
+
+	/** Pattern of perforce compiler warnings. */
+	private static final String CYCLICTEST_WARNING_PATTERN =
+		"^(WARN(ING)?|FATAL):(.*)$";
+
+	/**
+     * Creates a new instance of {@link RTTestsParser}.
+     */
+	public RTTestsParser() {
+		super(Messages._Warnings_RTTests_ParserName(),
+			  Messages._Warnings_RTTests_LinkName(),
+			  Messages._Warnings_RTTests_TrendName(),
+			  CYCLICTEST_WARNING_PATTERN, true);
+	}
+
+	@Override
+	protected Warning createWarning(final Matcher matcher) {
+		String category = matcher.group(1).trim();
+		String message = matcher.group(3).trim();
+		Priority priority = Priority.NORMAL;
+
+		if (category.equals("FATAL"))
+			priority = Priority.HIGH;
+
+		return createWarning("Nil", 0, category, message, priority);
+	}
+}

--- a/src/main/java/hudson/plugins/warnings/parser/RTTestsParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/RTTestsParser.java
@@ -26,7 +26,7 @@ public class RTTestsParser extends RegexpLineParser {
         super(Messages._Warnings_RTTests_ParserName(),
               Messages._Warnings_RTTests_LinkName(),
               Messages._Warnings_RTTests_TrendName(),
-              CYCLICTEST_WARNING_PATTERN, true);
+              CYCLICTEST_WARNING_PATTERN);
     }
 
     @Override

--- a/src/main/resources/hudson/plugins/warnings/parser/Messages.properties
+++ b/src/main/resources/hudson/plugins/warnings/parser/Messages.properties
@@ -259,3 +259,7 @@ Warnings.RFLint.TrendName=Robot Framework Warnings Trend
 Warnings.LinuxKernelOutput.ParserName=Linux Kernel Output Parser
 Warnings.LinuxKernelOutput.LinkName=Linux Kernel Output
 Warnings.LinuxKernelOutput.TrendName=Linux Kernel Output Trend
+
+Warnings.RTTests.ParserName=RT Tests Parser
+Warnings.RTTests.LinkName=RT Tests Output
+Warnings.RTTests.TrendName=RT Tests Trend

--- a/src/main/resources/hudson/plugins/warnings/parser/Messages_de.properties
+++ b/src/main/resources/hudson/plugins/warnings/parser/Messages_de.properties
@@ -228,10 +228,10 @@ Warnings.RFLint.ParserName=RFLint
 Warnings.RFLint.LinkName=RFLint Warnungen
 Warnings.RFLint.TrendName=RFLint Warnungen Trend
 
-Warnings.RTTests.ParserName=RT Tests Ausgaben Analyse
-Warnings.RTTests.LinkName=RT Tests Ausgaben
-Warnings.RTTests.TrendName=RT Tests Trend
-
 Warnings.LinuxKernelOutput.ParserName=Linux Kernel Ausgaben Analyse
 Warnings.LinuxKernelOutput.LinkName=Linux Kernel Ausgaben
 Warnings.LinuxKernelOutput.TrendName=Linux Kernel Ausgaben Trend
+
+Warnings.RTTests.ParserName=RT Tests Ausgaben Analyse
+Warnings.RTTests.LinkName=RT Tests Ausgaben
+Warnings.RTTests.TrendName=RT Tests Trend

--- a/src/test/java/hudson/plugins/warnings/parser/ParserRegistryIntegrationTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/ParserRegistryIntegrationTest.java
@@ -38,7 +38,7 @@ import hudson.plugins.warnings.GroovyParserTest;
  */
 public class ParserRegistryIntegrationTest {
     /** If you add a new parser then this value needs to be adapted. */
-    private static final int NUMBER_OF_AVAILABLE_PARSERS = 68;
+    private static final int NUMBER_OF_AVAILABLE_PARSERS = 69;
     private static final String OLD_ID_ECLIPSE_JAVA_COMPILER = "Eclipse Java Compiler";
     private static final String JAVA_WARNINGS_FILE = "deprecations.txt";
     private static final String OLD_ID_JAVA_COMPILER = "Java Compiler";

--- a/src/test/java/hudson/plugins/warnings/parser/RTTestsParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/RTTestsParserTest.java
@@ -13,6 +13,8 @@ import hudson.plugins.analysis.util.model.Priority;
 
 /**
  * Tests the class {@link RTTestsParser}.
+ *
+ * @author Benedikt Spranger
  */
 public class RTTestsParserTest extends ParserTester {
     private static final String TYPE = new RTTestsParser().getGroup();
@@ -20,8 +22,6 @@ public class RTTestsParserTest extends ParserTester {
 
     /**
      * Parses a file with three RTTests warnings.
-     *
-     * @author Benedikt Spranger
      *
      * @throws IOException
      *      if the file could not be read

--- a/src/test/java/hudson/plugins/warnings/parser/RTTestsParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/RTTestsParserTest.java
@@ -15,53 +15,55 @@ import hudson.plugins.analysis.util.model.Priority;
  * Tests the class {@link RTTestsParser}.
  */
 public class RTTestsParserTest extends ParserTester {
-	private static final String TYPE = new RTTestsParser().getGroup();
-	private static final String FILENAME = "cyclictest.log";
+    private static final String TYPE = new RTTestsParser().getGroup();
+    private static final String FILENAME = "cyclictest.log";
 
-	/**
+    /**
      * Parses a file with three RTTests warnings.
+     *
+     * @author Benedikt Spranger
      *
      * @throws IOException
      *      if the file could not be read
      */
-	@Test
-	public void testWarningsParser() throws IOException {
-		Collection<FileAnnotation> warnings = new RTTestsParser().parse(openFile());
+    @Test
+    public void testWarningsParser() throws IOException {
+        Collection<FileAnnotation> warnings = new RTTestsParser().parse(openFile());
 
-		assertEquals("Wrong number of warnings detected.", 4, warnings.size());
+        assertEquals("Wrong number of warnings detected.", 4, warnings.size());
 
-		Iterator<FileAnnotation> iterator = warnings.iterator();
-		FileAnnotation annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "Running on unknown kernel version...YMMV",
-					 "Nil",
-					 TYPE, "WARN", Priority.NORMAL);
+        Iterator<FileAnnotation> iterator = warnings.iterator();
+        FileAnnotation annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "Running on unknown kernel version...YMMV",
+                     "Nil",
+                     TYPE, "WARN", Priority.NORMAL);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "Running on unknown kernel version...YMMV",
-					 "Nil",
-					 TYPE, "WARNING", Priority.NORMAL);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "Running on unknown kernel version...YMMV",
+                     "Nil",
+                     TYPE, "WARNING", Priority.NORMAL);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "numa and smp options are mutually exclusive",
-					 "Nil",
-					 TYPE, "FATAL", Priority.HIGH);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "numa and smp options are mutually exclusive",
+                     "Nil",
+                     TYPE, "FATAL", Priority.HIGH);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "could not mount debugfs",
-					 "Nil",
-					 TYPE, "FATAL", Priority.HIGH);
-	}
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "could not mount debugfs",
+                     "Nil",
+                     TYPE, "FATAL", Priority.HIGH);
+    }
 
-	@Override
-	protected String getWarningsFile() {
-		return FILENAME;
-	}
+    @Override
+    protected String getWarningsFile() {
+        return FILENAME;
+    }
 }

--- a/src/test/java/hudson/plugins/warnings/parser/RTTestsParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/RTTestsParserTest.java
@@ -1,0 +1,67 @@
+package hudson.plugins.warnings.parser;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.junit.Test;
+
+import hudson.plugins.analysis.util.model.FileAnnotation;
+import hudson.plugins.analysis.util.model.Priority;
+
+/**
+ * Tests the class {@link RTTestsParser}.
+ */
+public class RTTestsParserTest extends ParserTester {
+	private static final String TYPE = new RTTestsParser().getGroup();
+	private static final String FILENAME = "cyclictest.log";
+
+	/**
+     * Parses a file with three RTTests warnings.
+     *
+     * @throws IOException
+     *      if the file could not be read
+     */
+	@Test
+	public void testWarningsParser() throws IOException {
+		Collection<FileAnnotation> warnings = new RTTestsParser().parse(openFile());
+
+		assertEquals("Wrong number of warnings detected.", 4, warnings.size());
+
+		Iterator<FileAnnotation> iterator = warnings.iterator();
+		FileAnnotation annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "Running on unknown kernel version...YMMV",
+					 "Nil",
+					 TYPE, "WARN", Priority.NORMAL);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "Running on unknown kernel version...YMMV",
+					 "Nil",
+					 TYPE, "WARNING", Priority.NORMAL);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "numa and smp options are mutually exclusive",
+					 "Nil",
+					 TYPE, "FATAL", Priority.HIGH);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "could not mount debugfs",
+					 "Nil",
+					 TYPE, "FATAL", Priority.HIGH);
+	}
+
+	@Override
+	protected String getWarningsFile() {
+		return FILENAME;
+	}
+}

--- a/src/test/resources/hudson/plugins/warnings/parser/cyclictest.log
+++ b/src/test/resources/hudson/plugins/warnings/parser/cyclictest.log
@@ -1,0 +1,4 @@
+WARN: Running on unknown kernel version...YMMV
+WARNING: Running on unknown kernel version...YMMV
+FATAL: numa and smp options are mutually exclusive
+FATAL: could not mount debugfs


### PR DESCRIPTION
RT-Tests (https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git) is a
Suite of real-time tests. These tests check the hardware and software
realtime capabilities of a system.

In the CI-RT Project (https://ci-rt.linutronix.de/RT-Test/about.jsp) these
tests are used to verify new Linux preempt-RT patches on well known
hardware. This parser is used to fetch errors from RT-Tests and prepare
them for Jenkins error summary.

Signed-off-by: Benedikt Spranger <b.spranger@linutronix.de>