### PR TITLE
parsers: Implement a Linux Kernel Output parser

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/LinuxKernelOutputParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/LinuxKernelOutputParser.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
 
 /**
- * A Parser for Linux Kernel Output detecting WARN() and BUGS()
+ * A Parser for Linux Kernel Output detecting WARN() and BUGS().
  *
  * @author Benedikt Spranger
  */
@@ -16,7 +16,7 @@ import org.apache.commons.lang.StringUtils;
 public class LinuxKernelOutputParser extends RegexpDocumentParser {
     private static final long serialVersionUID = 7580943036264863780L;
 
-    /** use single line mode: "." match all characters */
+    /** use single line mode: "." match all characters. */
     private static final String PREAMBLE = "(?s)";
 
     /** kernel timestamp
@@ -28,22 +28,22 @@ public class LinuxKernelOutputParser extends RegexpDocumentParser {
      */
     private static final String KERN_TIMESTAMP = "\\[[ ]*[0-9]+\\.[0-9]+\\]";
 
-    /** Error is BUG() or WARNING() */
-    private static final String BUGWARN = "(" +
-            KERN_TIMESTAMP +
-            ") ------------\\[ cut here \\]------------" +
-            "(.*?)" +
-            KERN_TIMESTAMP +
-            " (---\\[ end trace [0-9a-fA-F]+ \\]---)";
+    /** Error is BUG() or WARNING(). */
+    private static final String BUGWARN = "("
+        + KERN_TIMESTAMP
+        + ") ------------\\[ cut here \\]------------"
+        + "(.*?)"
+        + KERN_TIMESTAMP
+        + " (---\\[ end trace [0-9a-fA-F]+ \\]---)";
 
     /* A normal Kernel Output */
     private static final String KERNOUTPUT = "(" + KERN_TIMESTAMP + ")([^\n]*)";
 
-    /** Combine all sub-pattern to a global pattern */
+    /** Combine all sub-pattern to a global pattern. */
     private static final String LINUX_KERNEL_OUTPUT_WARNING_PATTERN =
-            PREAMBLE + "(" + BUGWARN + "|" + KERNOUTPUT + ")";
+        PREAMBLE + "(" + BUGWARN + "|" + KERNOUTPUT + ")";
 
-    /** Sub-pattern indices in global search pattern */
+    /** Sub-pattern indices in global search pattern. */
     private static final int ALL_OUTPUT = 1;
     private static final int BUGWARN_TIMESTAMP = 2;
     private static final int BUGWARN_CONTENT = 3;
@@ -54,7 +54,7 @@ public class LinuxKernelOutputParser extends RegexpDocumentParser {
     private static final Pattern FILE_PATH_PATTERN =
         Pattern.compile("(BUG|WARNING)[^/]*at[ ](((?:[^/]*/)*.*):(\\d+))?([^+!]*)");
 
-    /** Sub-pattern indices in file path search pattern */
+    /** Sub-pattern indices in file path search pattern. */
     private static final int ERROR_TYPE = 1;
     private static final int ERROR_INTERNAL = 2;
     private static final int ERROR_PATH = 3;
@@ -63,9 +63,9 @@ public class LinuxKernelOutputParser extends RegexpDocumentParser {
 
     public LinuxKernelOutputParser() {
         super(Messages._Warnings_LinuxKernelOutput_ParserName(),
-                Messages._Warnings_LinuxKernelOutput_LinkName(),
-                Messages._Warnings_LinuxKernelOutput_TrendName(),
-                LINUX_KERNEL_OUTPUT_WARNING_PATTERN, false);
+              Messages._Warnings_LinuxKernelOutput_LinkName(),
+              Messages._Warnings_LinuxKernelOutput_TrendName(),
+              LINUX_KERNEL_OUTPUT_WARNING_PATTERN, false);
     }
 
     @Override
@@ -81,20 +81,23 @@ public class LinuxKernelOutputParser extends RegexpDocumentParser {
         String kern = matcher.group(KERNOUTPUT_CONTENT);
 
         if (kern != null) {
-			String stripped = kern.replaceAll(KERN_TIMESTAMP, "").trim();
+            String stripped = kern.replaceAll(KERN_TIMESTAMP, "").trim();
 
             messageBuilder.append(stripped);
-        } else if (bug != null) {
+        }
+        else if (bug != null) {
             Matcher pathMatcher = FILE_PATH_PATTERN.matcher(bug);
             if (pathMatcher.find()) {
                 category = pathMatcher.group(ERROR_TYPE).trim();
                 filePath = pathMatcher.group(ERROR_PATH).trim();
                 lineNumber = getLineNumber(pathMatcher.group(ERROR_LINE));
 
-                if (category.equals("BUG"))
+                if ("BUG".equals(category)) {
                     priority = Priority.HIGH;
-                else
+                }
+                else {
                     priority = Priority.NORMAL;
+                }
 
                 messageBuilder.append(category);
                 messageBuilder.append(" in ");
@@ -106,10 +109,12 @@ public class LinuxKernelOutputParser extends RegexpDocumentParser {
                 toolTipBuilder.append("\n");
                 toolTipBuilder.append(matcher.group(BUGWARN_ENDTRACE));
                 toolTipBuilder.append("\n");
-            } else {
+            }
+            else {
                 messageBuilder.append(bug.replaceAll("(\\[[ ]*[0-9]+\\.[0-9]+\\])", "").trim());
             }
-        } else {
+        }
+        else {
             /** Ignore all other patterns */
             return FALSE_POSITIVE;
         }

--- a/src/main/java/hudson/plugins/warnings/parser/LinuxKernelOutputParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/LinuxKernelOutputParser.java
@@ -1,0 +1,136 @@
+package hudson.plugins.warnings.parser;
+
+import hudson.Extension;
+import hudson.plugins.analysis.util.model.Priority;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * A Parser for Linux Kernel Output detecting WARN() and BUGS()
+ *
+ * @author Benedikt Spranger
+ */
+@Extension
+public class LinuxKernelOutputParser extends RegexpDocumentParser {
+    private static final long serialVersionUID = 7580943036264863780L;
+
+    /** use single line mode: "." match all characters */
+    private static final String PREAMBLE = "(?s)";
+
+    /** kernel timestamp
+     * On a serial line aka serial console the output of Linux Kernel is
+     * interferred with output from other applications.
+     * A Linux kernel can be forced to add a timestamp to all outputs, either
+     * by a compile time option or a kernel command line flag.
+     * This is used to seperate the output.
+     */
+    private static final String KERN_TIMESTAMP = "\\[[ ]*[0-9]+\\.[0-9]+\\]";
+
+    /** Error is BUG() or WARNING() */
+    private static final String BUGWARN = "(" +
+            KERN_TIMESTAMP +
+            ") ------------\\[ cut here \\]------------" +
+            "(.*?)" +
+            KERN_TIMESTAMP +
+            " (---\\[ end trace [0-9a-fA-F]+ \\]---)";
+
+    /* A normal Kernel Output */
+    private static final String KERNOUTPUT = "(" + KERN_TIMESTAMP + ")([^\n]*)";
+
+    /** Combine all sub-pattern to a global pattern */
+    private static final String LINUX_KERNEL_OUTPUT_WARNING_PATTERN =
+            PREAMBLE + "(" + BUGWARN + "|" + KERNOUTPUT + ")";
+
+    /** Sub-pattern indices in global search pattern */
+    private static final int ALL_OUTPUT = 1;
+    private static final int BUGWARN_TIMESTAMP = 2;
+    private static final int BUGWARN_CONTENT = 3;
+    private static final int BUGWARN_ENDTRACE = 4;
+    private static final int KERNOUTPUT_TIMESTAMP = 5;
+    private static final int KERNOUTPUT_CONTENT = 6;
+    /** bug or warning file path pattern */
+    private static final Pattern FILE_PATH_PATTERN =
+        Pattern.compile("(BUG|WARNING)[^/]*at[ ](((?:[^/]*/)*.*):(\\d+))?([^+!]*)");
+
+    /** Sub-pattern indices in file path search pattern */
+    private static final int ERROR_TYPE = 1;
+    private static final int ERROR_INTERNAL = 2;
+    private static final int ERROR_PATH = 3;
+    private static final int ERROR_LINE = 4;
+    private static final int ERROR_FUNC = 5;
+
+    public LinuxKernelOutputParser() {
+        super(Messages._Warnings_LinuxKernelOutput_ParserName(),
+                Messages._Warnings_LinuxKernelOutput_LinkName(),
+                Messages._Warnings_LinuxKernelOutput_TrendName(),
+                LINUX_KERNEL_OUTPUT_WARNING_PATTERN, false);
+    }
+
+    @Override
+    protected Warning createWarning(Matcher matcher) {
+        StringBuilder messageBuilder = new StringBuilder();
+        StringBuilder toolTipBuilder = new StringBuilder();
+        String filePath = "Nil";
+        int lineNumber = 0;
+        String category = "Kernel Output";
+        Priority priority = Priority.LOW;
+
+        String bug = matcher.group(BUGWARN_CONTENT);
+        String kern = matcher.group(KERNOUTPUT_CONTENT);
+
+        if (kern != null) {
+			String stripped = kern.replaceAll(KERN_TIMESTAMP, "").trim();
+
+            messageBuilder.append(stripped);
+        } else if (bug != null) {
+            Matcher pathMatcher = FILE_PATH_PATTERN.matcher(bug);
+            if (pathMatcher.find()) {
+                category = pathMatcher.group(ERROR_TYPE).trim();
+                filePath = pathMatcher.group(ERROR_PATH).trim();
+                lineNumber = getLineNumber(pathMatcher.group(ERROR_LINE));
+
+                if (category.equals("BUG"))
+                    priority = Priority.HIGH;
+                else
+                    priority = Priority.NORMAL;
+
+                messageBuilder.append(category);
+                messageBuilder.append(" in ");
+                messageBuilder.append(pathMatcher.group(ERROR_FUNC).trim());
+                messageBuilder.append("()");
+
+                toolTipBuilder.append("------------[ cut here ]------------\n");
+                toolTipBuilder.append(bug.replaceAll("(\\[[ ]*[0-9]+\\.[0-9]+\\])", "").trim());
+                toolTipBuilder.append("\n");
+                toolTipBuilder.append(matcher.group(BUGWARN_ENDTRACE));
+                toolTipBuilder.append("\n");
+            } else {
+                messageBuilder.append(bug.replaceAll("(\\[[ ]*[0-9]+\\.[0-9]+\\])", "").trim());
+            }
+        } else {
+            /** Ignore all other patterns */
+            return FALSE_POSITIVE;
+        }
+
+        String message;
+        if (messageBuilder.length() == 0) {
+            message = "Unknown Error";
+        }
+        else {
+            message = messageBuilder.toString().replace("\n", "<br>");
+        }
+
+        Warning warning = createWarning(filePath, lineNumber, category, message, priority);
+
+        if (toolTipBuilder.length() > 0) {
+            String toolTip;
+
+            toolTip = toolTipBuilder.toString().replace("\n", "<br>");
+            warning.setToolTip(toolTip);
+        }
+
+        return warning;
+    }
+}

--- a/src/main/resources/hudson/plugins/warnings/parser/Messages.properties
+++ b/src/main/resources/hudson/plugins/warnings/parser/Messages.properties
@@ -255,3 +255,7 @@ Warnings.AnsibleLint.TrendName=Ansible Lint Warnings Trend
 Warnings.RFLint.ParserName=Robot Framework Lint
 Warnings.RFLint.LinkName=Robot Framework Warnings
 Warnings.RFLint.TrendName=Robot Framework Warnings Trend
+
+Warnings.LinuxKernelOutput.ParserName=Linux Kernel Output Parser
+Warnings.LinuxKernelOutput.LinkName=Linux Kernel Output
+Warnings.LinuxKernelOutput.TrendName=Linux Kernel Output Trend

--- a/src/main/resources/hudson/plugins/warnings/parser/Messages_de.properties
+++ b/src/main/resources/hudson/plugins/warnings/parser/Messages_de.properties
@@ -227,3 +227,11 @@ Warnings.SphinxBuild.TrendName=Sphinx-build Warnungen Trend
 Warnings.RFLint.ParserName=RFLint
 Warnings.RFLint.LinkName=RFLint Warnungen
 Warnings.RFLint.TrendName=RFLint Warnungen Trend
+
+Warnings.RTTests.ParserName=RT Tests Ausgaben Analyse
+Warnings.RTTests.LinkName=RT Tests Ausgaben
+Warnings.RTTests.TrendName=RT Tests Trend
+
+Warnings.LinuxKernelOutput.ParserName=Linux Kernel Ausgaben Analyse
+Warnings.LinuxKernelOutput.LinkName=Linux Kernel Ausgaben
+Warnings.LinuxKernelOutput.TrendName=Linux Kernel Ausgaben Trend

--- a/src/test/java/hudson/plugins/warnings/parser/LinuxKernelOutputParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/LinuxKernelOutputParserTest.java
@@ -14,185 +14,186 @@ import static org.junit.Assert.assertEquals;
  * Tests the class {@link LinuxKernelOutputParser}.
  */
 public class LinuxKernelOutputParserTest extends ParserTester {
-	private static final String TYPE = new LinuxKernelOutputParser().getGroup();
+    private static final String TYPE = new LinuxKernelOutputParser().getGroup();
 
-	/**
+    /**
      * Parse a kernel log file.
+     *
+     * @author Benedikt Spranger
      *
      * @throws IOException
      *      if the file could not be read
      */
-	@Test
-	public void testWarningsParser() throws IOException {
-		Collection<FileAnnotation> warnings = new LinuxKernelOutputParser().parse(openFile());
+    @Test
+    public void testWarningsParser() throws IOException {
+        Collection<FileAnnotation> warnings = new LinuxKernelOutputParser().parse(openFile());
 
-		assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 26, warnings.size());
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 26, warnings.size());
 
-		Iterator<FileAnnotation> iterator = warnings.iterator();
-		FileAnnotation annotation = iterator.next();
+        Iterator<FileAnnotation> iterator = warnings.iterator();
+        FileAnnotation annotation = iterator.next();
 
-		checkWarning(annotation,
-					 0,
-					 "ACPI: RSDP 0x00000000000F68D0 000014 (v00 BOCHS )",
-                                         "Nil",
-					 TYPE, "Kernel Output", Priority.LOW);
+        checkWarning(annotation,
+                     0,
+                     "ACPI: RSDP 0x00000000000F68D0 000014 (v00 BOCHS )",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "ACPI: RSDT 0x0000000007FE18DC 000030 (v01 BOCHS  BXPCRSDT 00000001 BXPC 00000001)",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "ACPI: RSDT 0x0000000007FE18DC 000030 (v01 BOCHS  BXPCRSDT 00000001 BXPC 00000001)",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "ACPI: FACP 0x0000000007FE17B8 000074 (v01 BOCHS  BXPCFACP 00000001 BXPC 00000001)",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "ACPI: FACP 0x0000000007FE17B8 000074 (v01 BOCHS  BXPCFACP 00000001 BXPC 00000001)",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "ACPI: DSDT 0x0000000007FE0040 001778 (v01 BOCHS  BXPCDSDT 00000001 BXPC 00000001)",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "ACPI: DSDT 0x0000000007FE0040 001778 (v01 BOCHS  BXPCDSDT 00000001 BXPC 00000001)",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "ACPI: FACS 0x0000000007FE0000 000040",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "ACPI: FACS 0x0000000007FE0000 000040",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "ACPI: APIC 0x0000000007FE182C 000078 (v01 BOCHS  BXPCAPIC 00000001 BXPC 00000001)",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "ACPI: APIC 0x0000000007FE182C 000078 (v01 BOCHS  BXPCAPIC 00000001 BXPC 00000001)",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "ACPI: HPET 0x0000000007FE18A4 000038 (v01 BOCHS  BXPCHPET 00000001 BXPC 00000001)",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "ACPI: HPET 0x0000000007FE18A4 000038 (v01 BOCHS  BXPCHPET 00000001 BXPC 00000001)",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "ACPI: 1 ACPI AML tables successfully acquired and loaded",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "ACPI: 1 ACPI AML tables successfully acquired and loaded",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "kworker/u2:0 (32) used greatest stack depth: 14256 bytes left",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "kworker/u2:0 (32) used greatest stack depth: 14256 bytes left",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "kworker/u2:0 (26) used greatest stack depth: 13920 bytes left",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "kworker/u2:0 (26) used greatest stack depth: 13920 bytes left",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "ACPI: Enabled 3 GPEs in block 00 to 0F",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "ACPI: Enabled 3 GPEs in block 00 to 0F",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "ACPI: PCI Interrupt Link [LNKC] enabled at IRQ 11",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "ACPI: PCI Interrupt Link [LNKC] enabled at IRQ 11",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "mdev (949) used greatest stack depth: 13888 bytes left",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "mdev (949) used greatest stack depth: 13888 bytes left",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "KABOOM: kaboom_init: WARNING",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "KABOOM: kaboom_init: WARNING",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     26,
+                     "WARNING in kaboom_init()",
+                     "/home/bene/work/rtl/test-description/tmp/linux-stable-rt/drivers/misc/kaboom.c",
+                     TYPE, "WARNING", Priority.NORMAL);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 26,
-					 "WARNING in kaboom_init()",
-					 "/home/bene/work/rtl/test-description/tmp/linux-stable-rt/drivers/misc/kaboom.c",
-					 TYPE, "WARNING", Priority.NORMAL);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "KABOOM: kaboom_init: ERR",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "KABOOM: kaboom_init: ERR",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "KABOOM: kaboom_init: CRIT",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "KABOOM: kaboom_init: CRIT",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "KABOOM: kaboom_init: ALERT",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "KABOOM: kaboom_init: ALERT",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "KABOOM: kaboom_init: EMERG",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "KABOOM: kaboom_init: EMERG",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     39,
+                     "BUG in ()",
+                     "/home/bene/work/rtl/test-description/tmp/linux-stable-rt/drivers/misc/kaboom.c",
+                     TYPE, "BUG", Priority.HIGH);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "sysrq: SysRq : Emergency Sync",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
+        annotation = iterator.next();
+        checkWarning(annotation,
+                     0,
+                     "sysrq: SysRq : Emergency Remount R/O",
+                     "Nil",
+                     TYPE, "Kernel Output", Priority.LOW);
+    }
 
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 39,
-					 "BUG in ()",
-					 "/home/bene/work/rtl/test-description/tmp/linux-stable-rt/drivers/misc/kaboom.c",
-					 TYPE, "BUG", Priority.HIGH);
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "sysrq: SysRq : Emergency Sync",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
-		annotation = iterator.next();
-		checkWarning(annotation,
-					 0,
-					 "sysrq: SysRq : Emergency Remount R/O",
-					 "Nil",
-                                         TYPE, "Kernel Output", Priority.LOW);
-	}
-
-	@Override
-	protected String getWarningsFile() {
-		return "kernel.log";
-	}
+    @Override
+    protected String getWarningsFile() {
+        return "kernel.log";
+    }
 }

--- a/src/test/java/hudson/plugins/warnings/parser/LinuxKernelOutputParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/LinuxKernelOutputParserTest.java
@@ -1,0 +1,198 @@
+package hudson.plugins.warnings.parser;
+
+import hudson.plugins.analysis.util.model.FileAnnotation;
+import hudson.plugins.analysis.util.model.Priority;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the class {@link LinuxKernelOutputParser}.
+ */
+public class LinuxKernelOutputParserTest extends ParserTester {
+	private static final String TYPE = new LinuxKernelOutputParser().getGroup();
+
+	/**
+     * Parse a kernel log file.
+     *
+     * @throws IOException
+     *      if the file could not be read
+     */
+	@Test
+	public void testWarningsParser() throws IOException {
+		Collection<FileAnnotation> warnings = new LinuxKernelOutputParser().parse(openFile());
+
+		assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 26, warnings.size());
+
+		Iterator<FileAnnotation> iterator = warnings.iterator();
+		FileAnnotation annotation = iterator.next();
+
+		checkWarning(annotation,
+					 0,
+					 "ACPI: RSDP 0x00000000000F68D0 000014 (v00 BOCHS )",
+                                         "Nil",
+					 TYPE, "Kernel Output", Priority.LOW);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "ACPI: RSDT 0x0000000007FE18DC 000030 (v01 BOCHS  BXPCRSDT 00000001 BXPC 00000001)",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "ACPI: FACP 0x0000000007FE17B8 000074 (v01 BOCHS  BXPCFACP 00000001 BXPC 00000001)",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "ACPI: DSDT 0x0000000007FE0040 001778 (v01 BOCHS  BXPCDSDT 00000001 BXPC 00000001)",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "ACPI: FACS 0x0000000007FE0000 000040",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "ACPI: APIC 0x0000000007FE182C 000078 (v01 BOCHS  BXPCAPIC 00000001 BXPC 00000001)",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "ACPI: HPET 0x0000000007FE18A4 000038 (v01 BOCHS  BXPCHPET 00000001 BXPC 00000001)",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "ACPI: 1 ACPI AML tables successfully acquired and loaded",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "kworker/u2:0 (32) used greatest stack depth: 14256 bytes left",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "kworker/u2:0 (26) used greatest stack depth: 13920 bytes left",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "ACPI: Enabled 3 GPEs in block 00 to 0F",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "ACPI: PCI Interrupt Link [LNKC] enabled at IRQ 11",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "mdev (949) used greatest stack depth: 13888 bytes left",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "KABOOM: kaboom_init: WARNING",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 26,
+					 "WARNING in kaboom_init()",
+					 "/home/bene/work/rtl/test-description/tmp/linux-stable-rt/drivers/misc/kaboom.c",
+					 TYPE, "WARNING", Priority.NORMAL);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "KABOOM: kaboom_init: ERR",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "KABOOM: kaboom_init: CRIT",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "KABOOM: kaboom_init: ALERT",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "KABOOM: kaboom_init: EMERG",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 39,
+					 "BUG in ()",
+					 "/home/bene/work/rtl/test-description/tmp/linux-stable-rt/drivers/misc/kaboom.c",
+					 TYPE, "BUG", Priority.HIGH);
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "sysrq: SysRq : Emergency Sync",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+		annotation = iterator.next();
+		checkWarning(annotation,
+					 0,
+					 "sysrq: SysRq : Emergency Remount R/O",
+					 "Nil",
+                                         TYPE, "Kernel Output", Priority.LOW);
+	}
+
+	@Override
+	protected String getWarningsFile() {
+		return "kernel.log";
+	}
+}

--- a/src/test/java/hudson/plugins/warnings/parser/LinuxKernelOutputParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/LinuxKernelOutputParserTest.java
@@ -12,14 +12,14 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Tests the class {@link LinuxKernelOutputParser}.
+ * @author Benedikt Spranger
+ *
  */
 public class LinuxKernelOutputParserTest extends ParserTester {
     private static final String TYPE = new LinuxKernelOutputParser().getGroup();
 
     /**
      * Parse a kernel log file.
-     *
-     * @author Benedikt Spranger
      *
      * @throws IOException
      *      if the file could not be read

--- a/src/test/java/hudson/plugins/warnings/parser/ParserRegistryIntegrationTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/ParserRegistryIntegrationTest.java
@@ -38,7 +38,7 @@ import hudson.plugins.warnings.GroovyParserTest;
  */
 public class ParserRegistryIntegrationTest {
     /** If you add a new parser then this value needs to be adapted. */
-    private static final int NUMBER_OF_AVAILABLE_PARSERS = 67;
+    private static final int NUMBER_OF_AVAILABLE_PARSERS = 68;
     private static final String OLD_ID_ECLIPSE_JAVA_COMPILER = "Eclipse Java Compiler";
     private static final String JAVA_WARNINGS_FILE = "deprecations.txt";
     private static final String OLD_ID_JAVA_COMPILER = "Java Compiler";

--- a/src/test/resources/hudson/plugins/warnings/parser/kernel.log
+++ b/src/test/resources/hudson/plugins/warnings/parser/kernel.log
@@ -1,0 +1,92 @@
+[    0.000000] ACPI: RSDP 0x00000000000F68D0 000014 (v00 BOCHS )
+[    0.000000] ACPI: RSDT 0x0000000007FE18DC 000030 (v01 BOCHS  BXPCRSDT 00000001 BXPC 00000001)
+[    0.000000] ACPI: FACP 0x0000000007FE17B8 000074 (v01 BOCHS  BXPCFACP 00000001 BXPC 00000001)
+[    0.000000] ACPI: DSDT 0x0000000007FE0040 001778 (v01 BOCHS  BXPCDSDT 00000001 BXPC 00000001)
+[    0.000000] ACPI: FACS 0x0000000007FE0000 000040
+[    0.000000] ACPI: APIC 0x0000000007FE182C 000078 (v01 BOCHS  BXPCAPIC 00000001 BXPC 00000001)
+[    0.000000] ACPI: HPET 0x0000000007FE18A4 000038 (v01 BOCHS  BXPCHPET 00000001 BXPC 00000001)
+[    0.003121] ACPI: 1 ACPI AML tables successfully acquired and loaded
+[    0.038642] kworker/u2:0 (32) used greatest stack depth: 14256 bytes left
+[    0.040025] kworker/u2:0 (26) used greatest stack depth: 13920 bytes left
+[    0.062404] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.
+[    0.086551] ACPI: Enabled 3 GPEs in block 00 to 0F
+[    0.235151] ACPI: PCI Interrupt Link [LNKC] enabled at IRQ 11
+[    0.577643] mdev (949) used greatest stack depth: 13888 bytes left
+udhcpc: started, v1.27.0.git
+Setting IP address 0.0.0.0 on eth0
+udhcpc: sending discover
+udhcpc: sending discover
+udhcpc: sending select for 10.0.2.15
+udhcpc: lease of 10.0.2.15 obtained, lease time 86400
+Setting IP address 10.0.2.15 on eth0
+Deleting routers
+route: SIOCDELRT: No such process
+Adding router 10.0.2.2
+Recreating /etc/resolv.conf
+ Adding DNS server 10.0.2.3
+[    3.635335] KABOOM: kaboom_init: WARNING
+[    3.635981] ------------[ cut here ]------------
+[    3.636783] WARNING: CPU: 0 PID: 983 at /home/bene/work/rtl/test-description/tmp/linux-stable-rt/drivers/misc/kaboom.c:26 kaboom_init+0x79/0xd0 [kaboom]()
+[    3.639116] Modules linked in: kaboom(+)
+[    3.639770] CPU: 0 PID: 983 Comm: modprobe Not tainted 4.4.47-rt58+ #21
+[    3.639770] Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.1-1 04/01/2014
+[    3.639773]  0000000000000000 ffff8800072c3ca0 ffffffff8132b4be 0000000000000000
+[    3.639774]  0000000000000009 ffff8800072c3cd8 ffffffff8105571d ffffffff81e1d040
+[    3.639775]  ffff880007247ea0 0000000000000000 ffffffffa0000000 ffffffffa0000300
+[    3.639775] Call Trace:
+[    3.639779]  [<ffffffff8132b4be>] dump_stack+0x4f/0x71
+[    3.639782]  [<ffffffff8105571d>] warn_slowpath_common+0x7d/0xd0
+[    3.639784]  [<ffffffffa0000000>] ? 0xffffffffa0000000
+[    3.639786]  [<ffffffff81055825>] warn_slowpath_null+0x15/0x30
+[    3.639787]  [<ffffffffa0000079>] kaboom_init+0x79/0xd0 [kaboom]
+[    3.639788]  [<ffffffff810003b1>] do_one_initcall+0x81/0x1a0
+[    3.639791]  [<ffffffff81127491>] do_init_module+0x5a/0x1bf
+[    3.639793]  [<ffffffff810d155a>] load_module+0x1d8a/0x2200
+[    3.639794]  [<ffffffff810cdc10>] ? m_show+0x190/0x190
+[    3.639796]  [<ffffffff810d1b8f>] SYSC_finit_module+0x8f/0xa0
+[    3.639798]  [<ffffffff810d1bb9>] SyS_finit_module+0x9/0x10
+[    3.639799]  [<ffffffff818f6c97>] entry_SYSCALL_64_fastpath+0x12/0x66
+[    3.639801] ---[ end trace 0000000000000002 ]---
+[    3.652237] KABOOM: kaboom_init: ERR
+[    3.652614] KABOOM: kaboom_init: CRIT
+[    3.652976] KABOOM: kaboom_init: ALERT
+[    3.653399] KABOOM: kaboom_init: EMERG
+[    3.653804] ------------[ cut here ]------------
+[    3.653805] kernel BUG at /home/bene/work/rtl/test-description/tmp/linux-stable-rt/drivers/misc/kaboom.c:39!
+[    3.653807] invalid opcode: 0000 [#1] PREEMPT SMP 
+[    3.653808] Modules linked in: kaboom(+)
+[    3.653810] CPU: 0 PID: 983 Comm: modprobe Tainted: G        W       4.4.47-rt58+ #21
+[    3.653811] Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.10.1-1 04/01/2014
+[    3.653812] task: ffff8800065ea640 ti: ffff8800072c0000 task.ti: ffff8800072c0000
+[    3.653816] RIP: 0010:[<ffffffffa000008e>]  [<ffffffffa000008e>] kaboom_init+0x8e/0xd0 [kaboom]
+[    3.653817] RSP: 0018:ffff8800072c3cf8  EFLAGS: 00010292
+[    3.653817] RAX: 000000000000001a RBX: ffffffff81e1d040 RCX: 0000000000000001
+[    3.653818] RDX: 0000000000000000 RSI: ffffffff81bc9b60 RDI: 00000000ffffffff
+[    3.653819] RBP: ffff8800072c3cf8 R08: 0000000000000002 R09: 000000000000017a
+[    3.653819] R10: 0000000000000004 R11: ffffffffffffffff R12: ffff880007247ea0
+[    3.653820] R13: 0000000000000000 R14: ffffffffa0000000 R15: ffffffffa0000300
+[    3.653821] FS:  00007f6b8a2b8700(0000) GS:ffff880007c00000(0000) knlGS:0000000000000000
+[    3.653822] CS:  0010 DS: 0000 ES: 0000 CR0: 000000008005003b
+[    3.653824] CR2: 000055ab8c3ec008 CR3: 0000000006b75000 CR4: 00000000000006f0
+[    3.653825] Stack:
+[    3.653826]  ffff8800072c3d68 ffffffff810003b1 ffff8800072c6040 0000000000000002
+[    3.653827]  ffff8800072c6040 0000000000000001 ffff8800064cc5a0 0000000000000002
+[    3.653829]  0000000000000018 ffffffffa0000300 ffffffffa0000300 ffffffffa0000350
+[    3.653829] Call Trace:
+[    3.653832]  [<ffffffff810003b1>] do_one_initcall+0x81/0x1a0
+[    3.653834]  [<ffffffff81127491>] do_init_module+0x5a/0x1bf
+[    3.653836]  [<ffffffff810d155a>] load_module+0x1d8a/0x2200
+[    3.653837]  [<ffffffff810cdc10>] ? m_show+0x190/0x190
+[    3.653839]  [<ffffffff810d1b8f>] SYSC_finit_module+0x8f/0xa0
+[    3.653841]  [<ffffffff810d1bb9>] SyS_finit_module+0x9/0x10
+[    3.653843]  [<ffffffff818f6c97>] entry_SYSCALL_64_fastpath+0x12/0x66
+[    3.653855] Code: e8 d2 71 12 e1 be 1a 00 00 00 48 c7 c7 c0 01 00 a0 e8 97 57 05 e1 eb c4 48 c7 c6 20 02 00 a0 48 c7 c7 96 01 00 a0 e8 ac 71 12 e1 <0f> 0b 48 c7 c6 20 02 00 a0 48 c7 c7 5a 01 00 a0 e8 97 71 12 e1 
+[    3.653857] RIP  [<ffffffffa000008e>] kaboom_init+0x8e/0xd0 [kaboom]
+[    3.653857]  RSP <ffff8800072c3cf8>
+[    3.676097] ---[ end trace 0000000000000003 ]---
+Segmentation fault
+[    3.677067] sysrq: SysRq : Emergency Sync
+[    3.677532] sysrq: SysRq : Emergency Remount R/O
+[    3.678035] Emergency Sync complete
+[    3.678437] Emergency Remount complete
+[    3.678851] sysrq: SysRq : Resetting


### PR DESCRIPTION
This parser can be used to detect output, errors and warnings printed by
the linux kernel. To access the kernel output from jenkins the kernel
needs to be booted in a way, that the console output is available in
jenkins (serial console + logger, netconsole + netcat, virsh console,
dmesg, ..)

The kernel needs to be configured with: CONFIG_PRINTK_TIME=y
to tag all Linux kernel output with a timestamp.
The Linux Kernel Output Parser differ console output on the basis
of this timestamp into kernel and userland output.

The kernel output is split up into three groups:

- high: Kernel bug/oops messages
- normal: Kernel warning messages
- low: all other kernel output

It is recommended to reduce the loglevel to 5 and specify quiet as boot
parameters: "loglevel=5 quiet"

Signed-off-by: Benedikt Spranger <b.spranger@linutronix.de>