### PR TITLE
Add fatal error to IAR parser

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/IarParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/IarParser.java
@@ -32,7 +32,7 @@ public class IarParser extends RegexpLineParser {
         super(Messages._Warnings_iar_ParserName(),
                 Messages._Warnings_iar_LinkName(),
                 Messages._Warnings_iar_TrendName(),
-                IAR_WARNING_PATTERN);
+                IAR_WARNING_PATTERN, true);
     }
 
     @Override
@@ -57,10 +57,8 @@ public class IarParser extends RegexpLineParser {
         String message = matcher.group(7);
         
         if( matcher.group(3) == null ) {
-            // createWarning( filename, line number, error number (Pe177), message, priority )
             return createWarning(matcher.group(8), 0, matcher.group(6), message, priority);
         }
-        // createWarning( filename, line number, error number (Pe177), message, priority )
         return createWarning(matcher.group(3), getLineNumber(matcher.group(4)), matcher.group(6), message, priority);
     }
           

--- a/src/test/java/hudson/plugins/warnings/parser/IarParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/IarParserTest.java
@@ -42,11 +42,7 @@ public class IarParserTest extends ParserTester {
      */
    @Test
     public void IAR_error1() throws IOException {
-        Collection<FileAnnotation> warnings = new IarParser().parse(openFile("issue8823.txt"));
-        Iterator<FileAnnotation> iterator = warnings.iterator();
-
-        FileAnnotation annotation = iterator.next();
-        
+        FileAnnotation annotation = getErrorNumber(1);
        checkWarning(annotation, 3767, "enumerated type mixed with another type",
                 "D:/continuousIntegration/modifiedcomps/forcedproduct/MHSM-Cascade/Cascade-Config/config/src/RDR_Config.c",
                 "Pe188", Priority.NORMAL);
@@ -61,12 +57,7 @@ public class IarParserTest extends ParserTester {
      */
    @Test
     public void IAR_error2() throws IOException {
-        Collection<FileAnnotation> warnings = new IarParser().parse(openFile("issue8823.txt"));
-        Iterator<FileAnnotation> iterator = warnings.iterator();
-        
-        FileAnnotation annotation = iterator.next();
-        annotation = iterator.next();
-        
+        FileAnnotation annotation = getErrorNumber(2);
         checkWarning(annotation, 3767, "enumerated type mixed with another type",
                 "D:/continuousIntegration/modifiedcomps/forcedproduct/MHSM-Cascade/Cascade-Config/config/src/RDR_Config.c",
                 "Pe188", Priority.NORMAL);
@@ -81,13 +72,7 @@ public class IarParserTest extends ParserTester {
      */
    @Test
     public void IAR_error3() throws IOException {
-        Collection<FileAnnotation> warnings = new IarParser().parse(openFile("issue8823.txt"));
-        Iterator<FileAnnotation> iterator = warnings.iterator();
-        
-        FileAnnotation annotation = iterator.next();
-        annotation = iterator.next();
-        annotation = iterator.next();
-        
+        FileAnnotation annotation = getErrorNumber(3);
         checkWarning(annotation, 3918, "enumerated type mixed with another type",
                 "D:/continuousIntegration/modifiedcomps/forcedproduct/MHSM-Cascade/Cascade-Config/config/src/RDR_Config.c",
                 "Pe188", Priority.NORMAL);
@@ -102,14 +87,7 @@ public class IarParserTest extends ParserTester {
      */
    @Test
     public void IAR_error4() throws IOException {
-        Collection<FileAnnotation> warnings = new IarParser().parse(openFile("issue8823.txt"));
-        Iterator<FileAnnotation> iterator = warnings.iterator();
-        
-        FileAnnotation annotation = iterator.next();
-        annotation = iterator.next();
-        annotation = iterator.next();
-        annotation = iterator.next();
-        
+        FileAnnotation annotation = getErrorNumber(4);
         checkWarning(annotation, 17, "cannot open source file \"System/ProcDef_LPC17xx.h\"",
                 "c:/JenkinsJobs/900ZH/Workspace/Product.900ZH/Src/System/AdditionalResources.h",
                 "Pe1696", Priority.HIGH);
@@ -124,15 +102,7 @@ public class IarParserTest extends ParserTester {
      */
    @Test
     public void IAR_error5() throws IOException {
-        Collection<FileAnnotation> warnings = new IarParser().parse(openFile("issue8823.txt"));
-        Iterator<FileAnnotation> iterator = warnings.iterator();
-        
-        FileAnnotation annotation = iterator.next();
-        annotation = iterator.next();
-        annotation = iterator.next();
-        annotation = iterator.next();
-        annotation = iterator.next();
-        
+        FileAnnotation annotation = getErrorNumber(5);
         checkWarning(annotation, 43, "variable \"pgMsgEnv\" was declared but never referenced",
                 "C:/dev/bsc/daqtask.c",
                 "Pe177", Priority.NORMAL);
@@ -147,15 +117,7 @@ public class IarParserTest extends ParserTester {
      */
    @Test
     public void IAR_error6() throws IOException {
-        Collection<FileAnnotation> warnings = new IarParser().parse(openFile("issue8823.txt"));
-        Iterator<FileAnnotation> iterator = warnings.iterator();
-        
-        FileAnnotation annotation = iterator.next();
-        annotation = iterator.next();
-        annotation = iterator.next();
-        annotation = iterator.next();
-        annotation = iterator.next();
-        annotation = iterator.next();
+        FileAnnotation annotation = getErrorNumber(6);
         // the \" is needed
         checkWarning(annotation, 0, "cannot open source file \"c:\\JenkinsJobs\\900ZH\\Workspace\\Lib\\Drivers\\_Obsolete\\Uart\\UartInterface.c\"",
                 "\"c:/JenkinsJobs/900ZH/Workspace/Lib/Drivers/_Obsolete/Uart/UartInterface.c\"",
@@ -166,5 +128,19 @@ public class IarParserTest extends ParserTester {
     protected String getWarningsFile() {
         return "iar-nowrap.log";
     }
-}
 
+    protected FileAnnotation getErrorNumber( final int number)
+    {
+        Collection<FileAnnotation> warnings = new IarParser().parse(openFile("issue8823.txt"));
+        Iterator<FileAnnotation> iterator = warnings.iterator();
+        FileAnnotation annotation = iterator.next();
+
+        for(int i = 1; i < number; i++)
+        {
+            annotation = iterator.next();
+        }
+
+        return annotation;
+    }
+    
+}

--- a/src/test/java/hudson/plugins/warnings/parser/IarParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/IarParserTest.java
@@ -20,55 +20,146 @@ public class IarParserTest extends ParserTester {
     private static final String TYPE = new IarParser().getGroup();
 
     /**
-     * Parses a file with warnings that are prefixed with exec tag.
+     * Parses a file with warnings/errors in all styles. it check the amount of error/warnings found
      *
      * @throws IOException
      *      if the file could not be read
      * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-8823">Issue 8823</a>
      */
     @Test
-    public void issue8823() throws IOException {
+    public void IAR_error_size() throws IOException {
         Collection<FileAnnotation> warnings = new IarParser().parse(openFile("issue8823.txt"));
 
-        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 3, warnings.size());
-        FileAnnotation annotation = warnings.iterator().next();
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 6, warnings.size());
+    }
+
+    /**
+     * Parses a file and check error number 1
+     *
+     * @throws IOException
+     *      if the file could not be read
+     * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-8823">Issue 8823</a>
+     */
+   @Test
+    public void IAR_error1() throws IOException {
+        Collection<FileAnnotation> warnings = new IarParser().parse(openFile("issue8823.txt"));
+        Iterator<FileAnnotation> iterator = warnings.iterator();
+
+        FileAnnotation annotation = iterator.next();
+        
+       checkWarning(annotation, 3767, "enumerated type mixed with another type",
+                "D:/continuousIntegration/modifiedcomps/forcedproduct/MHSM-Cascade/Cascade-Config/config/src/RDR_Config.c",
+                "Pe188", Priority.NORMAL);
+    }
+    
+     /**
+     * Parses a file and check error number 2
+     *
+     * @throws IOException
+     *      if the file could not be read
+     * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-8823">Issue 8823</a>
+     */
+   @Test
+    public void IAR_error2() throws IOException {
+        Collection<FileAnnotation> warnings = new IarParser().parse(openFile("issue8823.txt"));
+        Iterator<FileAnnotation> iterator = warnings.iterator();
+        
+        FileAnnotation annotation = iterator.next();
+        annotation = iterator.next();
+        
         checkWarning(annotation, 3767, "enumerated type mixed with another type",
                 "D:/continuousIntegration/modifiedcomps/forcedproduct/MHSM-Cascade/Cascade-Config/config/src/RDR_Config.c",
                 "Pe188", Priority.NORMAL);
     }
-
-    /**
-     * Parses a file with two IAR warnings.
+    
+     /**
+     * Parses a file and check error number 3
      *
      * @throws IOException
      *      if the file could not be read
+     * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-8823">Issue 8823</a>
      */
-    @Test
-    public void testWarningsParser() throws IOException {
-        Collection<FileAnnotation> warnings = new IarParser().parse(openFile());
-
+   @Test
+    public void IAR_error3() throws IOException {
+        Collection<FileAnnotation> warnings = new IarParser().parse(openFile("issue8823.txt"));
         Iterator<FileAnnotation> iterator = warnings.iterator();
-
-        assertEquals("Wrong number of warnings detected.", 9, warnings.size());
-        checkWarning(iterator.next(), 3, "an inline function cannot be root as well",
-                "/tmp/x/icc-error-memory.c", TYPE, "Be031", Priority.HIGH);
+        
+        FileAnnotation annotation = iterator.next();
+        annotation = iterator.next();
+        annotation = iterator.next();
+        
+        checkWarning(annotation, 3918, "enumerated type mixed with another type",
+                "D:/continuousIntegration/modifiedcomps/forcedproduct/MHSM-Cascade/Cascade-Config/config/src/RDR_Config.c",
+                "Pe188", Priority.NORMAL);
     }
-
-    /**
-     * Parses a file with one IAR warning in the new 6.3 format.
+    
+     /**
+     * Parses a file and check error number 4
      *
      * @throws IOException
      *      if the file could not be read
+     * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-8823">Issue 8823</a>
      */
-    @Test
-    public void testWarningsParserEwarm() throws IOException {
-        Collection<FileAnnotation> warnings = new IarParser().parse(openFile("iar-ewarm-6.3.txt"));
-
+   @Test
+    public void IAR_error4() throws IOException {
+        Collection<FileAnnotation> warnings = new IarParser().parse(openFile("issue8823.txt"));
         Iterator<FileAnnotation> iterator = warnings.iterator();
-
-        assertEquals("Wrong number of warnings detected.", 1, warnings.size());
-        checkWarning(iterator.next(), 43, "variable \"pgMsgEnv\" was declared but never referenced",
-                "C:/dev/bsc/daqtask.c", TYPE, "Pe177", Priority.NORMAL);
+        
+        FileAnnotation annotation = iterator.next();
+        annotation = iterator.next();
+        annotation = iterator.next();
+        annotation = iterator.next();
+        
+        checkWarning(annotation, 17, "cannot open source file \"System/ProcDef_LPC17xx.h\"",
+                "c:/JenkinsJobs/900ZH/Workspace/Product.900ZH/Src/System/AdditionalResources.h",
+                "Pe1696", Priority.HIGH);
+    }
+    
+    /**
+     * Parses a file and check error number 5
+     *
+     * @throws IOException
+     *      if the file could not be read
+     * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-8823">Issue 8823</a>
+     */
+   @Test
+    public void IAR_error5() throws IOException {
+        Collection<FileAnnotation> warnings = new IarParser().parse(openFile("issue8823.txt"));
+        Iterator<FileAnnotation> iterator = warnings.iterator();
+        
+        FileAnnotation annotation = iterator.next();
+        annotation = iterator.next();
+        annotation = iterator.next();
+        annotation = iterator.next();
+        annotation = iterator.next();
+        
+        checkWarning(annotation, 43, "variable \"pgMsgEnv\" was declared but never referenced",
+                "C:/dev/bsc/daqtask.c",
+                "Pe177", Priority.NORMAL);
+    }
+    
+     /**
+     * Parses a file and check error number 6
+     *
+     * @throws IOException
+     *      if the file could not be read
+     * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-8823">Issue 8823</a>
+     */
+   @Test
+    public void IAR_error6() throws IOException {
+        Collection<FileAnnotation> warnings = new IarParser().parse(openFile("issue8823.txt"));
+        Iterator<FileAnnotation> iterator = warnings.iterator();
+        
+        FileAnnotation annotation = iterator.next();
+        annotation = iterator.next();
+        annotation = iterator.next();
+        annotation = iterator.next();
+        annotation = iterator.next();
+        annotation = iterator.next();
+        // the \" is needed
+        checkWarning(annotation, 0, "cannot open source file \"c:\\JenkinsJobs\\900ZH\\Workspace\\Lib\\Drivers\\_Obsolete\\Uart\\UartInterface.c\"",
+                "\"c:/JenkinsJobs/900ZH/Workspace/Lib/Drivers/_Obsolete/Uart/UartInterface.c\"",
+                "Pe1696", Priority.HIGH);
     }
 
     @Override

--- a/src/test/java/hudson/plugins/warnings/parser/IarParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/IarParserTest.java
@@ -129,8 +129,7 @@ public class IarParserTest extends ParserTester {
         return "iar-nowrap.log";
     }
 
-    protected FileAnnotation getErrorNumber( final int number)
-    {
+    protected FileAnnotation getErrorNumber( final int number) throws IOException {
         Collection<FileAnnotation> warnings = new IarParser().parse(openFile("issue8823.txt"));
         Iterator<FileAnnotation> iterator = warnings.iterator();
         FileAnnotation annotation = iterator.next();

--- a/src/test/resources/hudson/plugins/warnings/parser/issue8823.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/issue8823.txt
@@ -1,3 +1,6 @@
 [exec] D:\continuousIntegration\modifiedcomps\forcedproduct\MHSM-Cascade\Cascade-Config\config\src\RDR_Config.c(3767) : Warning[Pe188]: enumerated type mixed with another type
 [exec] D:\continuousIntegration\modifiedcomps\forcedproduct\MHSM-Cascade\Cascade-Config\config\src\RDR_Config.c(3767) : Warning[Pe188]: enumerated type mixed with another type
 [exec] D:\continuousIntegration\modifiedcomps\forcedproduct\MHSM-Cascade\Cascade-Config\config\src\RDR_Config.c(3918) : Warning[Pe188]: enumerated type mixed with another type
+c:\JenkinsJobs\900ZH\Workspace\Product.900ZH\Src\System\AdditionalResources.h(17) : Fatal Error[Pe1696]: cannot open source file "System/ProcDef_LPC17xx.h"
+C:\dev\bsc\daqtask.c(43) : Warning[Pe177]: variable "pgMsgEnv" was declared but never referenced
+Fatal Error[Pe1696]: cannot open source file "c:\JenkinsJobs\900ZH\Workspace\Lib\Drivers\_Obsolete\Uart\UartInterface.c"


### PR DESCRIPTION
Add the short error, Fatal error detection and better detection via the regular expression.

- update test cases too have one test at the time.
- update the resource file so all cases can be tested via the unit test