### PR TITLE
Add comments to Eclipse regex

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/EclipseParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/EclipseParser.java
@@ -18,10 +18,16 @@ import hudson.plugins.analysis.util.model.Priority;
 public class EclipseParser extends RegexpDocumentParser {
     private static final long serialVersionUID = 425883472788422955L;
     private static final String ANT_ECLIPSE_WARNING_PATTERN =
-            "\\[?(WARNING|ERROR)\\]?\\s*(?:in)?\\s*(.*)(?:\\(at line\\s*(\\d+)\\)|:\\[(\\d+)).*" +
-            "(?:\\r?\\n[^\\^\\n]*){1,3}" +
-            "\\r?\\n(.*)([\\^]+).*" +
-            "\\r?\\n(?:\\s*\\[.*\\]\\s*)?(.*)";
+            "\\[?(WARNING|ERROR)\\]?" +      // group 1 'type': WARNING or ERROR in optional []
+            "\\s*(?:in)?" +                  // optional " in"
+            "\\s*(.*)" +                     // group 2 'filename'
+            "(?:\\(at line\\s*(\\d+)\\)|" +  // either group 3 'lineNumber': at line dd
+            ":\\[(\\d+)).*" +                // or group 4 'rowNumber': eg :[row,col] - col ignored
+            "(?:\\r?\\n[^\\^\\n]*){1,3}" +   // 1 or 3 ignored lines (no column pointer) eg source excerpt
+            "\\r?\\n(.*)" +                  // newline then group 5 (indent for column pointers)
+            "([\\^]+).*" +                   // group 6 column pointers (^^^^^)
+            "\\r?\\n(?:\\s*\\[.*\\]\\s*)?" + // newline then optional ignored text in [] (eg [javac])
+            "(.*)";                          // group 7 'message'
 
     /**
      * Creates a new instance of {@link EclipseParser}.


### PR DESCRIPTION
It took me a while to work out that this parser isn't ideal for my purposes (Eclipse compiler warnings when run via takari-lifecycle-plugin, which look totally different and don't need multi-line regexes), but before that I added comments to make the regex more understandable. Please adapt, correct or use them if they're useful.

Note: I haven't changed the content of the regex string at all; it's just broken up into more lines with comments.

(Edit: for anyone wondering, the javac warnings parser seems to work perfectly well for takari-lifecycle-plugin+Eclipse JDT.)