### PR TITLE
GnuMakeGccParser now handles MSYS make on windows

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/GnuMakeGccParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/GnuMakeGccParser.java
@@ -29,14 +29,25 @@ public class GnuMakeGccParser extends RegexpLineParser {
             + ")";
     private String directory = "";
 
+    private boolean isWindows;
+
     /**
      * Creates a new instance of {@link GnuMakeGccParser}.
      */
     public GnuMakeGccParser() {
+        this(System.getProperty("os.name"));
+    }
+
+    /**
+     * Creates a new instance of {@link GnuMakeGccParser} assuming the operating system given in os
+     * @param os A string representing the operating system - mainly used for faking
+     */
+    public GnuMakeGccParser(final String os) {
         super(Messages._Warnings_GnuMakeGcc_ParserName(),
                 Messages._Warnings_GnuMakeGcc_LinkName(),
                 Messages._Warnings_GnuMakeGcc_TrendName(),
                 GNUMAKEGCC_WARNING_PATTERN);
+        isWindows = os.toLowerCase().contains("windows");
     }
 
     @Override
@@ -76,8 +87,20 @@ public class GnuMakeGccParser extends RegexpLineParser {
         }
     }
 
+    private String fixMsysTypeDirectory(String directory)
+    {
+        if (isWindows && directory.matches("/[a-z]/.*"))
+        {
+            //MSYS make on Windows replaces the drive letter and colon (C:) with unix-type absolute paths (/c/)
+            //Reverse this operation here
+            directory = directory.substring(1, 2) + ":" + directory.substring(2);
+        }
+        return directory;
+    }
+
     private Warning handleDirectory(final Matcher matcher) {
         directory = matcher.group(10) + SLASH;
+        directory = fixMsysTypeDirectory(directory);
 
         return FALSE_POSITIVE;
     }

--- a/src/main/java/hudson/plugins/warnings/parser/GnuMakeGccParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/GnuMakeGccParser.java
@@ -25,7 +25,7 @@ public class GnuMakeGccParser extends RegexpLineParser {
             + "(?:.*\\[.*\\])?\\s*" // ANT_TASK
             + "(.*\\.[chpimxsola0-9]+):(\\d+):(?:\\d+:)? (warning|error): (.*)$" // GCC 4 warning
             + ")|("
-            + "(^g?make\\[.*\\]: Entering directory)\\s*(['`]((.*))\\')" // handle make entering directory
+            + "(^g?make(\\[.*\\])?: Entering directory)\\s*(['`]((.*))\\')" // handle make entering directory
             + ")";
     private String directory = "";
 
@@ -77,7 +77,7 @@ public class GnuMakeGccParser extends RegexpLineParser {
     }
 
     private Warning handleDirectory(final Matcher matcher) {
-        directory = matcher.group(9) + SLASH;
+        directory = matcher.group(10) + SLASH;
 
         return FALSE_POSITIVE;
     }

--- a/src/test/java/hudson/plugins/warnings/parser/GnuMakeGccParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/GnuMakeGccParserTest.java
@@ -121,7 +121,7 @@ public class GnuMakeGccParserTest extends ParserTester {
      */
     @Test
     public void checkCorrectPath_NonWindows() throws IOException {
-        testOsSpecificPath("Ubuntu", "/c");
+        checkOsSpecificPath("Ubuntu", "/c");
     }
 
     /**
@@ -133,7 +133,7 @@ public class GnuMakeGccParserTest extends ParserTester {
      */
     @Test
     public void checkCorrectPath_Windows() throws IOException {
-        testOsSpecificPath("Windows NT", "c:");
+        checkOsSpecificPath("Windows NT", "c:");
     }
 
     /** 

--- a/src/test/resources/hudson/plugins/warnings/parser/gnuMakeGcc.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/gnuMakeGcc.txt
@@ -34,7 +34,7 @@ warnings.cc:14:   instantiated from here
 warnings.cc:6: warning: passing 'Test' chooses 'int' over 'unsigned int'
 warnings.cc:6: warning:   in call to 'std::basic_ostream<_CharT, _Traits>& std::basic_ostream<_CharT, _Traits>::operator<<(int) [with _CharT = char, _Traits = std::char_traits<char>]'
 
-make[2]: Entering directory '/dir1/dir2/dir3'
+make: Entering directory '/dir1/dir2/dir3'
 =============== Issue 5605
 In file included from /usr/include/c++/4.3/backward/hash_set:64,
                  from /usr/include/boost/graph/adjacency_list.hpp:25,
@@ -46,6 +46,6 @@ fo:oo.cpp: In function 'int main()':
 fo:oo.cpp:8: error: 'bar' was not declared in this scope
 fo:oo.cpp:12: error: expected ';' before 'return'
 foo bar.hello*world:12:
-make[2]: Leaving directory '/dir1/dir2/dir3'
+make: Leaving directory '/dir1/dir2/dir3'
 make[1]: Leaving directory `/dir1/dir2'
 make[0]: Leaving directory `/dir1'

--- a/src/test/resources/hudson/plugins/warnings/parser/gnuMakeGcc.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/gnuMakeGcc.txt
@@ -14,7 +14,7 @@ foo.so: undefined reference to 'missing_symbol'
 
 src/test_simple_sgs_message.cxx:52: warning: large integer implicitly truncated to unsigned type
 
-make[1]: Entering directory `/c/dir2'
+make[1]: Entering directory `/dir1/dir2'
 
 ================ Issue 3897 (not valid gcc4 errors -> should be undetected)
 /dir1/dir2/file.c:12:15: file.h: No such file or directory
@@ -34,7 +34,7 @@ warnings.cc:14:   instantiated from here
 warnings.cc:6: warning: passing 'Test' chooses 'int' over 'unsigned int'
 warnings.cc:6: warning:   in call to 'std::basic_ostream<_CharT, _Traits>& std::basic_ostream<_CharT, _Traits>::operator<<(int) [with _CharT = char, _Traits = std::char_traits<char>]'
 
-make: Entering directory '/dir1/dir2/dir3'
+make[2]: Entering directory '/dir1/dir2/dir3'
 =============== Issue 5605
 In file included from /usr/include/c++/4.3/backward/hash_set:64,
                  from /usr/include/boost/graph/adjacency_list.hpp:25,
@@ -46,6 +46,19 @@ fo:oo.cpp: In function 'int main()':
 fo:oo.cpp:8: error: 'bar' was not declared in this scope
 fo:oo.cpp:12: error: expected ';' before 'return'
 foo bar.hello*world:12:
-make: Leaving directory '/dir1/dir2/dir3'
+make[2]: Leaving directory '/dir1/dir2/dir3'
 make[1]: Leaving directory `/dir1/dir2'
 make[0]: Leaving directory `/dir1'
+
+============== Checking "entering directory" without recursion level ==========
+make: Entering directory `/dir4'
+zoidberg.c:5:70: warning: Your code is bad, and you should feel bad!
+make: Leaving directory `/dir4'
+
+
+============== Check for MSYS-type paths on windows =================
+
+This should be converted to c:/dir5, but only on windows
+make[1]: Entering directory `/c/dir5'
+grail.cpp:20: warning: I'm warning you! He's got huge, sharp... er... He can leap about.
+make[1]: Leaving directory `/c/dir5'

--- a/src/test/resources/hudson/plugins/warnings/parser/gnuMakeGcc.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/gnuMakeGcc.txt
@@ -14,7 +14,7 @@ foo.so: undefined reference to 'missing_symbol'
 
 src/test_simple_sgs_message.cxx:52: warning: large integer implicitly truncated to unsigned type
 
-make[1]: Entering directory `/dir1/dir2'
+make[1]: Entering directory `/c/dir2'
 
 ================ Issue 3897 (not valid gcc4 errors -> should be undetected)
 /dir1/dir2/file.c:12:15: file.h: No such file or directory


### PR DESCRIPTION
The gnu makefile parser can now correctly parse the directory when the makefile doesn't output the recursion level in the "entering directory" message.
i.e: The parser used to expect a message like "make[2]: Entering directory", but can now also handle  "make: Entering directory"
Edit:
Added a new commit which handles the peculiar directories of MSYS make on Windows. Msys uses absolute paths in the style "/c/blah/blah/" instead of "c:/blah/blah". 