### PR TITLE
ClangParser: parse warning category less aggressively

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/ClangParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/ClangParser.java
@@ -14,7 +14,10 @@ import hudson.plugins.analysis.util.model.Priority;
 @Extension
 public class ClangParser extends RegexpLineParser {
     private static final long serialVersionUID = -3015592762345283182L;
-    private static final String CLANG_WARNING_PATTERN = "^\\s*(?:\\d+%)?([^%]*?):(\\d+):(?:(\\d+):)?(?:(?:\\{\\d+:\\d+-\\d+:\\d+\\})+:)?\\s*(warning|[^\\[\\]]*error):\\s*(.*?)(?:\\[(.*)\\])?$";
+    private static final String CLANG_WARNING_PATTERN =
+        "^\\s*(?:\\d+%)?([^%]*?):(\\d+):(?:(\\d+):)?" +
+        "(?:(?:\\{\\d+:\\d+-\\d+:\\d+\\})+:)?\\s*(warning|[^\\[\\]]*error):" +
+        "\\s*(.*?)(?:\\[([^\\[]*)\\])?$";
 
     /**
      * Creates a new instance of {@link ClangParser}.

--- a/src/test/java/hudson/plugins/warnings/parser/ClangParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/ClangParserTest.java
@@ -95,7 +95,7 @@ public class ClangParserTest extends ParserTester {
     public void testWarningsParser() throws IOException {
         Collection<FileAnnotation> warnings = new ClangParser().parse(openFile());
 
-        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 8, warnings.size());
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 9, warnings.size());
 
         Iterator<FileAnnotation> iterator = warnings.iterator();
         FileAnnotation annotation = iterator.next();
@@ -147,6 +147,13 @@ public class ClangParserTest extends ParserTester {
                 "invalid operands to binary expression ('int *' and '_Complex float')",
                 "exprs.c",
                 TYPE, DEFAULT_CATEGORY, Priority.NORMAL);
+
+        annotation = iterator.next();
+        checkWarning(annotation,
+                103, 55,
+                "passing 'uint8_t [11]' to parameter of type 'const char *' converts between pointers to integer types with different sign",
+                "t.c",
+                TYPE, "-Wpointer-sign", Priority.NORMAL);
      }
 
     @Override

--- a/src/test/resources/hudson/plugins/warnings/parser/apple-llvm-clang.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/apple-llvm-clang.txt
@@ -13,3 +13,5 @@ t.c:3:11: warning: conversion specifies type 'char *' but the argument has type 
 t.c:3:11: warning: conversion specifies type 'char *' but the argument has type 'int' [-Wformat,Format String]
 
 exprs.c:47:15:{47:8-47:14}{47:17-47:24}: warning: invalid operands to binary expression ('int *' and '_Complex float')
+
+t.c:103:55: warning: passing 'uint8_t [11]' to parameter of type 'const char *' converts between pointers to integer types with different sign [-Wpointer-sign]


### PR DESCRIPTION
The clang warning regex was matching the first left bracket in the
detail for the category, but the warning detail itself may contain
brackets e.g. to describe an array type.  Now, only match the last left
bracket.