### PR TITLE
Adapt SbtScalacParser to SBT 1.x warnings format

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/SbtScalacParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/SbtScalacParser.java
@@ -17,7 +17,7 @@ public class SbtScalacParser extends RegexpLineParser {
     private static final String SCALA_SMALL_ICON = WarningsDescriptor.IMAGE_PREFIX + "scala-24x24.png";
     private static final String SCALA_LARGE_ICON = WarningsDescriptor.IMAGE_PREFIX + "scala-48x48.png";
 
-    private static final String SBT_WARNING_PATTERN = "^(\\[warn\\]|\\[error\\])\\s*(.*):(\\d+):\\s*(.*)$";
+    private static final String SBT_WARNING_PATTERN = "^(\\[warn\\]|\\[error\\])\\s*(.*?):(\\d+)(?::\\d+)?:\\s*(.*)$";
 
     /**
      * Creates a new instance of {@link SbtScalacParser}.

--- a/src/test/java/hudson/plugins/warnings/parser/SbtScalacParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/SbtScalacParserTest.java
@@ -20,12 +20,16 @@ public class SbtScalacParserTest extends ParserTester {
     @Test
     public void basicFunctionality() throws IOException {
         Collection<FileAnnotation> warnings = new SbtScalacParser().parse(openFile());
-        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 2, warnings.size());
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 4, warnings.size());
         Iterator<FileAnnotation> iter = warnings.iterator();
         checkWarning(iter.next(), 111, "method stop in class Thread is deprecated: see corresponding Javadoc for more information.",
                 "/home/user/.jenkins/jobs/job/workspace/path/SomeFile.scala", DEFAULT_CATEGORY, Priority.NORMAL);
         checkWarning(iter.next(), 9, "';' expected but identifier found.",
                 "/home/user/.jenkins/jobs/job/workspace/another/path/SomeFile.scala", DEFAULT_CATEGORY, Priority.HIGH);
+        checkWarning(iter.next(), 4, "implicit numeric widening",
+                     "/home/user/.jenkins/jobs/job/workspace/Main.scala", DEFAULT_CATEGORY, Priority.NORMAL);
+        checkWarning(iter.next(), 5, "Invalid literal number",
+                     "/home/user/.jenkins/jobs/job/workspace/Main.scala", DEFAULT_CATEGORY, Priority.HIGH);
     }
 
     @Override

--- a/src/test/resources/hudson/plugins/warnings/parser/sbtScalac.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/sbtScalac.txt
@@ -1,4 +1,5 @@
 [warn] /home/user/.jenkins/jobs/job/workspace/path/SomeFile.scala:111: method stop in class Thread is deprecated: see corresponding Javadoc for more information.
 [warn]     Thread.currentThread.stop()
 [error] /home/user/.jenkins/jobs/job/workspace/another/path/SomeFile.scala:9: ';' expected but identifier found.
-
+[warn] /home/user/.jenkins/jobs/job/workspace/Main.scala:4:18: implicit numeric widening
+[error] /home/user/.jenkins/jobs/job/workspace/Main.scala:5:11: Invalid literal number


### PR DESCRIPTION
The newly released version uses a slightly different warnings format, it prints
the line and column information separated by a colon after the file name.

This leads to an error when clicking on an entry in the warnings list currently,
since the line number is parsed as part of the file name:

```
01 Copying the source file '/local/jenkins/workspace/project/app/actors/SlackActor.scala:25' from the workspace to the build folder '35705b61.tmp' on the Jenkins master failed.
02 Is the file '/local/jenkins/workspace/project/app/actors/SlackActor.scala:25' a valid filename?
```

This commit fixes the regex such that the file name stops at the first colon -
when there is a column number in the warning message.