### PR TITLE
Add parser for run-clang-tidy.py output

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/ClangTidyParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/ClangTidyParser.java
@@ -24,8 +24,7 @@ public class ClangTidyParser extends RegexpLineParser {
         super(Messages._Warnings_ClangTidy_ParserName(),
                 Messages._Warnings_ClangTidy_LinkName(),
                 Messages._Warnings_ClangTidy_TrendName(),
-                CLANG_TIDY_WARNING_PATTERN,
-                false);
+                CLANG_TIDY_WARNING_PATTERN);
     }
 
     @Override
@@ -35,8 +34,8 @@ public class ClangTidyParser extends RegexpLineParser {
         int lineNumber = getLineNumber(matcher.group(2));
         int column = getLineNumber(matcher.group(3));
         String type = matcher.group(4);
-        String category = matcher.group(6);
         String message = matcher.group(5);
+        String category = matcher.group(6);
 
         Priority priority;
         if (type.contains("error")) {
@@ -45,13 +44,8 @@ public class ClangTidyParser extends RegexpLineParser {
         else {
             priority = Priority.NORMAL;
         }
-        Warning warning;
-        if (category == null) {
-            warning = createWarning(filename, lineNumber, message, priority);
-        }
-        else {
-            warning = createWarning(filename, lineNumber, category, message, priority);
-        }
+
+        Warning warning = createWarning(filename, lineNumber, category, message, priority);
         warning.setColumnPosition(column);
         return warning;
     }

--- a/src/main/java/hudson/plugins/warnings/parser/ClangTidyParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/ClangTidyParser.java
@@ -1,0 +1,58 @@
+package hudson.plugins.warnings.parser;
+
+import java.util.regex.Matcher;
+
+import hudson.Extension;
+
+import hudson.plugins.analysis.util.model.Priority;
+
+/**
+ * A parser for the clang-tidy static analysis warnings.
+ *
+ * @author Ryan Schaefer
+ */
+@Extension
+public class ClangTidyParser extends RegexpLineParser {
+    private static final long serialVersionUID = -3015592762345283182L;
+    private static final String CLANG_TIDY_WARNING_PATTERN =
+        "([^\\s]+):(\\d+):(\\d+): (warning|error): (.*?) \\[(.*?)\\]$";
+
+    /**
+     * Creates a new instance of {@link ClangTidyParser}.
+     */
+    public ClangTidyParser() {
+        super(Messages._Warnings_ClangTidy_ParserName(),
+                Messages._Warnings_ClangTidy_LinkName(),
+                Messages._Warnings_ClangTidy_TrendName(),
+                CLANG_TIDY_WARNING_PATTERN,
+                false);
+    }
+
+    @Override
+    protected Warning createWarning(final Matcher matcher) {
+
+        String filename = matcher.group(1);
+        int lineNumber = getLineNumber(matcher.group(2));
+        int column = getLineNumber(matcher.group(3));
+        String type = matcher.group(4);
+        String category = matcher.group(6);
+        String message = matcher.group(5);
+
+        Priority priority;
+        if (type.contains("error")) {
+            priority = Priority.HIGH;
+        }
+        else {
+            priority = Priority.NORMAL;
+        }
+        Warning warning;
+        if (category == null) {
+            warning = createWarning(filename, lineNumber, message, priority);
+        }
+        else {
+            warning = createWarning(filename, lineNumber, category, message, priority);
+        }
+        warning.setColumnPosition(column);
+        return warning;
+    }
+}

--- a/src/main/resources/hudson/plugins/warnings/parser/Messages.properties
+++ b/src/main/resources/hudson/plugins/warnings/parser/Messages.properties
@@ -263,3 +263,6 @@ Warnings.LinuxKernelOutput.TrendName=Linux Kernel Output Trend
 Warnings.RTTests.ParserName=RT Tests Parser
 Warnings.RTTests.LinkName=RT Tests Output
 Warnings.RTTests.TrendName=RT Tests Trend
+Warnings.ClangTidy.ParserName=Clang-Tidy
+Warnings.ClangTidy.LinkName=Clang-Tidy
+Warnings.ClangTidy.TrendName=Clang-Tidy Warnings Trend

--- a/src/test/java/hudson/plugins/warnings/parser/ClangTidyParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/ClangTidyParserTest.java
@@ -12,9 +12,9 @@ import hudson.plugins.analysis.util.model.FileAnnotation;
 import hudson.plugins.analysis.util.model.Priority;
 
 /**
- * Tests the class {@link ClangParser}.
+ * Tests the class {@link ClangTidyParser}.
  *
- * @author Neil Davis
+ * @author Ryan Schaefer
  */
 public class ClangTidyParserTest extends ParserTester {
     private static final String TYPE = new ClangTidyParser().getGroup();
@@ -29,7 +29,69 @@ public class ClangTidyParserTest extends ParserTester {
     public void testWarningsParser() throws IOException {
         Collection<FileAnnotation> warnings = new ClangTidyParser().parse(openFile());
 
-        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 5, warnings.size());
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 6, warnings.size());
+
+        Iterator<FileAnnotation> iterator = warnings.iterator();
+
+        FileAnnotation annotation = iterator.next();
+        checkWarning(annotation,
+                1,
+                8,
+                "implicit conversion changes signedness: 'int' to 'uint32_t' (aka 'unsigned int')",
+                "src/../src/main.cpp",
+                TYPE,
+                "clang-diagnostic-sign-conversion",
+                Priority.NORMAL);
+
+        annotation = iterator.next();
+        checkWarning(annotation,
+                10,
+                20,
+                "implicit conversion changes signedness: 'int' to 'uint32_t' (aka 'unsigned int')",
+                "/src/main.cpp",
+                TYPE,
+                "clang-diagnostic-sign-conversion",
+                Priority.NORMAL);
+
+        annotation = iterator.next();
+        checkWarning(annotation,
+                83,
+                20,
+                "implicit conversion changes signedness: 'int' to 'uint32_t' (aka 'unsigned int')",
+                "/path/to/project/src/test2.cpp",
+                TYPE,
+                "clang-diagnostic-sign-conversion",
+                Priority.NORMAL);
+
+        annotation = iterator.next();
+        checkWarning(annotation,
+                25,
+                15,
+                "suggest braces around initialization of subobject",
+                "/path/to/project/src/test2.cpp",
+                TYPE,
+                "clang-diagnostic-missing-braces",
+                Priority.NORMAL);
+
+        annotation = iterator.next();
+        checkWarning(annotation,
+                29,
+                15,
+                "suggest braces around initialization of subobject",
+                "/path/to/project/src/test2.cpp",
+                TYPE,
+                "clang-diagnostic-missing-braces",
+                Priority.NORMAL);
+
+        annotation = iterator.next();
+        checkWarning(annotation,
+                4,
+                10,
+                "'dbus/dbus.h' file not found",
+                "/path/to/project/src/error_test.cpp",
+                TYPE,
+                "clang-diagnostic-error",
+                Priority.HIGH);
     }
 
     @Override

--- a/src/test/java/hudson/plugins/warnings/parser/ClangTidyParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/ClangTidyParserTest.java
@@ -1,0 +1,39 @@
+package hudson.plugins.warnings.parser;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+import hudson.plugins.analysis.util.model.FileAnnotation;
+import hudson.plugins.analysis.util.model.Priority;
+
+/**
+ * Tests the class {@link ClangParser}.
+ *
+ * @author Neil Davis
+ */
+public class ClangTidyParserTest extends ParserTester {
+    private static final String TYPE = new ClangTidyParser().getGroup();
+
+    /**
+     * Verifies that all messages are correctly parsed.
+     *
+     * @throws IOException
+     *             in case of an error
+     */
+    @Test
+    public void testWarningsParser() throws IOException {
+        Collection<FileAnnotation> warnings = new ClangTidyParser().parse(openFile());
+
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 5, warnings.size());
+    }
+
+    @Override
+    protected String getWarningsFile() {
+        return "ClangTidy.txt";
+    }
+}

--- a/src/test/java/hudson/plugins/warnings/parser/ParserRegistryIntegrationTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/ParserRegistryIntegrationTest.java
@@ -38,7 +38,7 @@ import hudson.plugins.warnings.GroovyParserTest;
  */
 public class ParserRegistryIntegrationTest {
     /** If you add a new parser then this value needs to be adapted. */
-    private static final int NUMBER_OF_AVAILABLE_PARSERS = 69;
+    private static final int NUMBER_OF_AVAILABLE_PARSERS = 70;
     private static final String OLD_ID_ECLIPSE_JAVA_COMPILER = "Eclipse Java Compiler";
     private static final String JAVA_WARNINGS_FILE = "deprecations.txt";
     private static final String OLD_ID_JAVA_COMPILER = "Java Compiler";

--- a/src/test/resources/hudson/plugins/warnings/parser/ClangTidy.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/ClangTidy.txt
@@ -86,11 +86,11 @@ clang-tidy-5.0 -header-filter=src/,include/ -p=/path/to/project /path/to/project
 warning: /path/to/project/tools/yocto-toolchain/sysroots/core2-64-fslc-linux/usr/include/qt5/QtQml: 'linker' input unused [clang-diagnostic-unused-command-line-argument]
 
 # Relative File
-clang-tidy-5.0 -header-filter=src/,include/ -p=/path/to/project src/main.cpp:1:8: warning: implicit conversion changes signedness: 'int' to 'uint32_t' (aka 'unsigned int') [clang-diagnostic-sign-conversion]
+clang-tidy-5.0 -header-filter=src/,include/ -p=/path/to/project src/../src/main.cpp:1:8: warning: implicit conversion changes signedness: 'int' to 'uint32_t' (aka 'unsigned int') [clang-diagnostic-sign-conversion]
     case 6: return static_cast<int>(phase); break;
 
 # Absolute File
-clang-tidy-5.0 -header-filter=src/,include/ -p=/path/to/project src/main.cpp:10:20: warning: implicit conversion changes signedness: 'int' to 'uint32_t' (aka 'unsigned int') [clang-diagnostic-sign-conversion]
+clang-tidy-5.0 -header-filter=src/,include/ -p=/path/to/project /src/main.cpp:10:20: warning: implicit conversion changes signedness: 'int' to 'uint32_t' (aka 'unsigned int') [clang-diagnostic-sign-conversion]
     case 6: return static_cast<int>(phase); break;
 
 # File with multiple errors - Warning for each instance
@@ -105,3 +105,7 @@ clang-tidy-5.0 -header-filter=src/,include/ -p=/path/to/project /path/to/project
             { 0, 1, 2, 3, 4, 5, 6, 7 }
               ^
               {                     }
+
+# Error Test
+/path/to/project/src/error_test.cpp:4:10: error: 'dbus/dbus.h' file not found [clang-diagnostic-error]
+#include <dbus/dbus.h>

--- a/src/test/resources/hudson/plugins/warnings/parser/ClangTidy.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/ClangTidy.txt
@@ -1,0 +1,107 @@
+# run-clang-tidy outputs check list - Don't match
+Enabled checks:
+    clang-analyzer-apiModeling.google.GTest
+    clang-analyzer-core.CallAndMessage
+    clang-analyzer-core.DivideZero
+    clang-analyzer-core.DynamicTypePropagation
+    clang-analyzer-core.NonNullParamChecker
+    clang-analyzer-core.NullDereference
+    clang-analyzer-core.StackAddressEscape
+    clang-analyzer-core.UndefinedBinaryOperatorResult
+    clang-analyzer-core.VLASize
+    clang-analyzer-core.builtin.BuiltinFunctions
+    clang-analyzer-core.builtin.NoReturnFunctions
+    clang-analyzer-core.uninitialized.ArraySubscript
+    clang-analyzer-core.uninitialized.Assign
+    clang-analyzer-core.uninitialized.Branch
+    clang-analyzer-core.uninitialized.CapturedBlockVariable
+    clang-analyzer-core.uninitialized.UndefReturn
+    clang-analyzer-cplusplus.NewDelete
+    clang-analyzer-cplusplus.NewDeleteLeaks
+    clang-analyzer-cplusplus.SelfAssignment
+    clang-analyzer-deadcode.DeadStores
+    clang-analyzer-llvm.Conventions
+    clang-analyzer-nullability.NullPassedToNonnull
+    clang-analyzer-nullability.NullReturnedFromNonnull
+    clang-analyzer-nullability.NullableDereferenced
+    clang-analyzer-nullability.NullablePassedToNonnull
+    clang-analyzer-nullability.NullableReturnedFromNonnull
+    clang-analyzer-optin.cplusplus.VirtualCall
+    clang-analyzer-optin.mpi.MPI-Checker
+    clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker
+    clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker
+    clang-analyzer-optin.performance.Padding
+    clang-analyzer-optin.portability.UnixAPI
+    clang-analyzer-osx.API
+    clang-analyzer-osx.NumberObjectConversion
+    clang-analyzer-osx.ObjCProperty
+    clang-analyzer-osx.SecKeychainAPI
+    clang-analyzer-osx.cocoa.AtSync
+    clang-analyzer-osx.cocoa.ClassRelease
+    clang-analyzer-osx.cocoa.Dealloc
+    clang-analyzer-osx.cocoa.IncompatibleMethodTypes
+    clang-analyzer-osx.cocoa.Loops
+    clang-analyzer-osx.cocoa.MissingSuperCall
+    clang-analyzer-osx.cocoa.NSAutoreleasePool
+    clang-analyzer-osx.cocoa.NSError
+    clang-analyzer-osx.cocoa.NilArg
+    clang-analyzer-osx.cocoa.NonNilReturnValue
+    clang-analyzer-osx.cocoa.ObjCGenerics
+    clang-analyzer-osx.cocoa.RetainCount
+    clang-analyzer-osx.cocoa.SelfInit
+    clang-analyzer-osx.cocoa.SuperDealloc
+    clang-analyzer-osx.cocoa.UnusedIvars
+    clang-analyzer-osx.cocoa.VariadicMethodTypes
+    clang-analyzer-osx.coreFoundation.CFError
+    clang-analyzer-osx.coreFoundation.CFNumber
+    clang-analyzer-osx.coreFoundation.CFRetainRelease
+    clang-analyzer-osx.coreFoundation.containers.OutOfBounds
+    clang-analyzer-osx.coreFoundation.containers.PointerSizedValues
+    clang-analyzer-security.FloatLoopCounter
+    clang-analyzer-security.insecureAPI.UncheckedReturn
+    clang-analyzer-security.insecureAPI.getpw
+    clang-analyzer-security.insecureAPI.gets
+    clang-analyzer-security.insecureAPI.mkstemp
+    clang-analyzer-security.insecureAPI.mktemp
+    clang-analyzer-security.insecureAPI.rand
+    clang-analyzer-security.insecureAPI.strcpy
+    clang-analyzer-security.insecureAPI.vfork
+    clang-analyzer-unix.API
+    clang-analyzer-unix.Malloc
+    clang-analyzer-unix.MallocSizeof
+    clang-analyzer-unix.MismatchedDeallocator
+    clang-analyzer-unix.StdCLibraryFunctions
+    clang-analyzer-unix.Vfork
+    clang-analyzer-unix.cstring.BadSizeArg
+    clang-analyzer-unix.cstring.NullArg
+    clang-analyzer-valist.CopyToSelf
+    clang-analyzer-valist.Uninitialized
+    clang-analyzer-valist.Unterminated
+
+
+# Okay File - No warnings created
+clang-tidy-5.0 -header-filter=src/,include/ -p=/path/to/project /path/to/project/src/tests/main.cpp
+
+# Warnings to not match
+warning: /path/to/project/tools/yocto-toolchain/sysroots/core2-64-fslc-linux/usr/include/qt5/QtQml: 'linker' input unused [clang-diagnostic-unused-command-line-argument]
+
+# Relative File
+clang-tidy-5.0 -header-filter=src/,include/ -p=/path/to/project src/main.cpp:1:8: warning: implicit conversion changes signedness: 'int' to 'uint32_t' (aka 'unsigned int') [clang-diagnostic-sign-conversion]
+    case 6: return static_cast<int>(phase); break;
+
+# Absolute File
+clang-tidy-5.0 -header-filter=src/,include/ -p=/path/to/project src/main.cpp:10:20: warning: implicit conversion changes signedness: 'int' to 'uint32_t' (aka 'unsigned int') [clang-diagnostic-sign-conversion]
+    case 6: return static_cast<int>(phase); break;
+
+# File with multiple errors - Warning for each instance
+clang-tidy-5.0 -header-filter=src/,include/ -p=/path/to/project /path/to/project/src/test2.cpp:83:20: warning: implicit conversion changes signedness: 'int' to 'uint32_t' (aka 'unsigned int') [clang-diagnostic-sign-conversion]
+    case 6: return static_cast<int>(phase); break;
+                   ^
+/path/to/project/src/test2.cpp:25:15: warning: suggest braces around initialization of subobject [clang-diagnostic-missing-braces]
+            { 0, 1, 2, 3, 4, 5, 6, 7 }
+              ^
+              {                     }
+/path/to/project/src/test2.cpp:29:15: warning: suggest braces around initialization of subobject [clang-diagnostic-missing-braces]
+            { 0, 1, 2, 3, 4, 5, 6, 7 }
+              ^
+              {                     }


### PR DESCRIPTION
Clang-tidy is a static analysis utility. run-clang-tidy-*.py is a helper
python script for running clang-tidy on an entire project