### PR TITLE
 Tweak javac parser to capture Kotlin Gradle warnings

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/JavacParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/JavacParser.java
@@ -41,7 +41,7 @@ public class JavacParser extends RegexpLineParser {
 
     @Override
     protected boolean isLineInteresting(final String line) {
-        return line.contains("[");
+        return line.contains("[") || line.contains("w:");
     }
 
     @Override

--- a/src/main/java/hudson/plugins/warnings/parser/JavacParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/JavacParser.java
@@ -18,15 +18,16 @@ public class JavacParser extends RegexpLineParser {
 
     private static final long serialVersionUID = 7199325311690082782L;
     private static final String JAVAC_WARNING_PATTERN =
-            "^(?:\\[\\p{Alnum}*\\]\\s+)?" + // optional alphanumerics
-            "(?:\\[WARNING\\]\\s+)?" +      // optional [WARNING]
-            "([^\\[\\(]*):\\s*" +           // group 1: filename
-            "[\\[\\(]" +                    // [ or (
-            "(\\d+)[.,;]*" +                // group 2: line number
-            "\\s?(\\d+)?" +                 // group 3: optional column
-            "[\\]\\)]\\s*" +                // ] or )
-            "(?:\\[(\\w+)\\])?" +           // group 4: optional category
-            "\\s*(.*)$";                    // group 5: message
+            "^(?:\\[\\p{Alnum}*\\]\\s+)?" +   // optional alphanumerics
+            "(?:(?:\\[WARNING\\]|w:)\\s+)?" + // optional [WARNING] or :
+            "([^\\[\\(]*):\\s*" +             // group 1: filename
+            "[\\[\\(]" +                      // [ or (
+            "(\\d+)[.,;]*" +                  // group 2: line number
+            "\\s?(\\d+)?" +                   // group 3: optional column
+            "[\\]\\)]\\s*" +                  // ] or )
+            ":?" +                            // optional :
+            "(?:\\[(\\w+)\\])?" +             // group 4: optional category
+            "\\s*(.*)$";                      // group 5: message
 
     /**
      * Creates a new instance of {@link JavacParser}.

--- a/src/test/java/hudson/plugins/warnings/parser/JavacParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/JavacParserTest.java
@@ -51,9 +51,21 @@ public class JavacParserTest extends ParserTester {
         assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 62, java7.size());
     }
 
+    /**
+     * Parses a warning log written by Maven containing Kotlin 4 warnings.
+     */
     @Test
     public void kotlinMavenPlugin() throws IOException {
         Collection<FileAnnotation> warnings = parse("kotlin-maven-plugin.txt");
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 4, warnings.size());
+    }
+
+    /**
+     * Parses a warning log written by Gradle containing Kotlin 4 warnings.
+     */
+    @Test
+    public void kotlinGradle() throws IOException {
+        Collection<FileAnnotation> warnings = parse("kotlin-gradle.txt");
         assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 4, warnings.size());
     }
 

--- a/src/test/resources/hudson/plugins/warnings/parser/kotlin-gradle.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/kotlin-gradle.txt
@@ -1,0 +1,10 @@
+> Configure project :app
+Configuration 'compile' in project ':app' is deprecated. Use 'implementation' instead.
+registerResGeneratingTask is deprecated, use registerGeneratedFolders(FileCollection)
+registerResGeneratingTask is deprecated, use registerGeneratedFolders(FileCollection)
+registerResGeneratingTask is deprecated, use registerGeneratedFolders(FileCollection)
+app: 'annotationProcessor' dependencies won't be recognized as kapt annotation processors. Please change the configuration name to 'kapt' for these artifacts: 'com.android.databinding:compiler:3.0.1'.
+w: /project/app/src/main/java/ui/Activity.kt: (214, 35): Unchecked cast: Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */
+w: /project/app/src/main/java/ui/Activity.kt: (424, 29): Unchecked cast: Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */
+w: /project/app/src/main/java/ui/Activity.kt: (440, 28): Unchecked cast: Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */
+w: /project/app/src/main/java/ui/Activity.kt: (458, 33): Unchecked cast: Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */


### PR DESCRIPTION
This PR extends what has already been done in https://github.com/jenkinsci/warnings-plugin/pull/99 for capturing Kotlin warnings thrown during a Maven Build. As already mentioned by @seanf in that PR, we only have to look for `w:` (instead of `[WARNING]`) at the start and we have to parse away an extra colon after the line and column numbers. So these are the basic changes to the RegEx this PR contains.

In addition, this PR makes lines containing `w:` interesting (as Kotlin warnings thrown by Gradle do not contain a `[` anymore) and updates the tests to include an example case.

I ran the tests locally using `mvn test` and they ran through just fine. Let me know if I have to check anything else 🙂.