### PR TITLE
More restrictive maven console parser

### DIFF
--- a/src/main/java/hudson/plugins/warnings/parser/MavenConsoleParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/MavenConsoleParser.java
@@ -49,9 +49,9 @@ public class MavenConsoleParser extends RegexpLineParser {
      */
     public MavenConsoleParser() {
         super(Messages._Warnings_Maven_ParserName(),
-              Messages._Warnings_Maven_LinkName(),
-              Messages._Warnings_Maven_TrendName(),
-              PATTERN, true);
+                Messages._Warnings_Maven_LinkName(),
+                Messages._Warnings_Maven_TrendName(),
+                PATTERN, true);
     }
 
     @Override

--- a/src/main/java/hudson/plugins/warnings/parser/MavenConsoleParser.java
+++ b/src/main/java/hudson/plugins/warnings/parser/MavenConsoleParser.java
@@ -27,16 +27,31 @@ public class MavenConsoleParser extends RegexpLineParser {
 
     private static final long serialVersionUID = 1737791073711198075L;
 
-    private static final String PATTERN = "^.*\\[(WARNING|ERROR)\\]\\s*(.*)$";
+    /**
+     * Pattern for identifying warning or error maven logs.
+     * <pre>
+     * Pattern:
+     * (.*\s\s|)           -> Capture group 1 matches either empty string (e.g. [WARNING] some log) or some text followed by exactly two
+     *                        spaces (e.g. 22:07:27  [WARNING] some log)
+     * \[(WARNING|ERROR)\] -> Capture group 2 matches either [WARNING] or [ERROR]
+     * \s*                 -> matches zero or more spaces
+     * (.*)                -> Capture group 3 matches zero or more characters except line breaks, represents the actual error message
+     * </pre>
+     * <p>
+     * Typical maven logs:
+     * 1) 22:07:27  [WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
+     * 2) [ERROR] The POM for org.codehaus.groovy.maven:gmaven-plugin:jar:1.1 is missing
+     */
+    private static final String PATTERN = "^(.*\\s\\s|)\\[(WARNING|ERROR)\\]\\s*(.*)$";
 
     /**
      * Creates a new instance of {@link MavenConsoleParser}.
      */
     public MavenConsoleParser() {
         super(Messages._Warnings_Maven_ParserName(),
-                Messages._Warnings_Maven_LinkName(),
-                Messages._Warnings_Maven_TrendName(),
-                PATTERN, true);
+              Messages._Warnings_Maven_LinkName(),
+              Messages._Warnings_Maven_TrendName(),
+              PATTERN, true);
     }
 
     @Override
@@ -48,7 +63,10 @@ public class MavenConsoleParser extends RegexpLineParser {
     protected Warning createWarning(final Matcher matcher) {
         Priority priority;
         String category;
-        if (ERROR.equals(matcher.group(1))) {
+        String errorOrWarningGroup = matcher.group(2);
+        String errorOrWarningMessage = matcher.group(3);
+
+        if (ERROR.equals(errorOrWarningGroup)) {
             priority = Priority.HIGH;
             category = "Error";
         }
@@ -56,7 +74,7 @@ public class MavenConsoleParser extends RegexpLineParser {
             priority = Priority.NORMAL;
             category = "Warning";
         }
-        return createWarning(CONSOLE, getCurrentLine(), category, matcher.group(2), priority);
+        return createWarning(CONSOLE, getCurrentLine(), category, errorOrWarningMessage, priority);
     }
 
     // FIXME: post processing is quite slow for large number of warnings, see JENKINS-25278

--- a/src/test/java/hudson/plugins/warnings/parser/MavenConsoleParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/MavenConsoleParserTest.java
@@ -29,10 +29,10 @@ public class MavenConsoleParserTest extends ParserTester {
     public void testParsing() throws IOException {
         Collection<FileAnnotation> warnings = new MavenConsoleParser().parse(openFile());
 
-        assertEquals("Wrong number of warnings detected.", 4, warnings.size());
+        assertEquals("Wrong number of warnings detected.", 5, warnings.size());
         AnnotationContainer result = new DefaultAnnotationContainer(warnings);
         assertEquals("Wrong number of errors detected.", 2, result.getNumberOfAnnotations(Priority.HIGH));
-        assertEquals("Wrong number of warnings detected.", 2, result.getNumberOfAnnotations(Priority.NORMAL));
+        assertEquals("Wrong number of warnings detected.", 3, result.getNumberOfAnnotations(Priority.NORMAL));
     }
 
     /**

--- a/src/test/resources/hudson/plugins/warnings/parser/maven-console.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/maven-console.txt
@@ -24,3 +24,10 @@
 22:07:30  [WARNING] Failed to retrieve plugin descriptor for org.codehaus.groovy.maven:gmaven-plugin:1.1: Plugin org.codehaus.groovy.maven:gmaven-plugin:1.1 or one of its dependencies could not be resolved: Failed to read artifact descriptor for org.codehaus.groovy.maven:gmaven-plugin:jar:1.1
 22:07:30  [WARNING] The POM for org.codehaus.groovy.maven:gmaven-plugin:jar:1.1 is missing, no dependency information available
 22:07:30  [WARNING] Failed to retrieve plugin descriptor for org.codehaus.groovy.maven:gmaven-plugin:1.1: Plugin org.codehaus.groovy.maven:gmaven-plugin:1.1 or one of its dependencies could not be resolved: Failed to read artifact descriptor for org.codehaus.groovy.maven:gmaven-plugin:jar:1.1
+
+!-- Maven logs without starting timestamp
+[INFO] Downloading https://nexus.faktorzehn.de/content/groups/private/org/codehaus/groovy/maven/gmaven-plugin/1.1/gmaven-plugin-1.1.pom
+[WARNING] The POM for org.codehaus.groovy.maven:gmaven-plugin:jar:1.1 is missing, no dependency information available
+
+!-- Usual application log line containing warning/error indication
+2018-06-14 09:57:10,478 INFO [THREAD NAME] this.is.my.namespace.TestClass Current state is [WARNING]. This should not be parsed as maven warning.


### PR DESCRIPTION
First of all, thanks for the neat plugin, helps a lot to quickly pinpoint errors on our CI pipeline.

With this pull request i made the MavenConsoleParser regex a bit more restrictive as we encountered a lot of falls positives during our CI runs when our application logs looked like the following:

`018-06-14 04:04:09,803 INFO [SOME THREAD] some.namespace.SomeClass State changed to: [ERROR] - other state: asdf`
The old pattern matched any sentence starting with some optional text, followed by [ERROR] or [WARNING], followed by an optional space and then some mandatory text.

The pattern now expects either a text starting with [ERROR] or [WARNING] directly or some string (e.g. the date) followed by exactly two spaces followed by [ERROR] or [WARNING].
This log pattern matches the examples from the unit test (which i extended) and the maven logs i experienced so far :)

Examples:
`22:07:27  [WARNING] For this reason, future Maven versions might no longer support building such malformed projects.`
`[ERROR] The POM for org.codehaus.groovy.maven:gmaven-plugin:jar:1.1 is missing`

