### PR TITLE
GHS compiler regex fix

### DIFF
--- a/src/test/java/hudson/plugins/warnings/parser/GhsMultiParserTest.java
+++ b/src/test/java/hudson/plugins/warnings/parser/GhsMultiParserTest.java
@@ -27,7 +27,7 @@ public class GhsMultiParserTest extends ParserTester {
     public void parseMultiLine() throws IOException {
         Collection<FileAnnotation> warnings = new GhsMultiParser().parse(openFile());
 
-        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 3, warnings.size());
+        assertEquals(WRONG_NUMBER_OF_WARNINGS_DETECTED, 4, warnings.size());
 
         Iterator<FileAnnotation> iterator = warnings.iterator();
         FileAnnotation annotation = iterator.next();
@@ -44,6 +44,11 @@ public class GhsMultiParserTest extends ParserTester {
         checkWarning(annotation, 9,
                 "extra\n          \";\" ignored\n  TEST_DSS( CHECK_4TH_CONFIG_DATA, 18, 142, 'F');",
                 "/maindir/tests/TestCase_1601.cpp\"", TYPE, "#381-D",
+                Priority.NORMAL);
+	annotation = iterator.next();
+        checkWarning(annotation, 23,
+                "variable \"myvar\" was declared but never referenced\n\n  static const uint32 myvar",
+                "D:/workspace/TEST/mytest.c\"", TYPE, "#177-D",
                 Priority.NORMAL);
     }
 

--- a/src/test/resources/hudson/plugins/warnings/parser/ghsmulti.txt
+++ b/src/test/resources/hudson/plugins/warnings/parser/ghsmulti.txt
@@ -17,3 +17,9 @@ Compiling TestCase_1601.cpp because TestCase_1601.o does not exist
                                                                   ^
 Integrating TestExec1601 because it does not exist
 Done
+
+"D:/workspace/TEST/mytest.c", line 23: warning #177-D: variable "myvar" was declared but never referenced
+
+  static const uint32 myvar
+
+                      ^


### PR DESCRIPTION
If the path doesn't start with `.` the GHS parser doesn't correctly parse the path and hence the filtering options (i.e. includePattern) don't work properly.